### PR TITLE
chore: license check in posttest

### DIFF
--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -1,0 +1,5 @@
+{
+  "packageWhitelist": [
+    "log-driver"  // https://github.com/googleapis/nodejs-common/issues/16
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "cover": "nyc --reporter=lcov mocha --require intelli-espower-loader test/*.js && nyc report",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "test-no-cover": "repo-tools test run --cmd mocha -- test/*.js --no-timeouts",
-    "test": "repo-tools test run --cmd npm -- run cover"
+    "test": "repo-tools test run --cmd npm -- run cover",
+    "posttest": "npm run license-check",
+    "license-check": "jsgl --local ."
   },
   "dependencies": {
     "array-uniq": "^1.0.3",
@@ -72,6 +74,7 @@
     "eslint-plugin-prettier": "^2.3.1",
     "ink-docstrap": "^1.3.0",
     "intelli-espower-loader": "^1.0.1",
+    "js-green-licenses": "^0.2.1",
     "jsdoc": "^3.5.5",
     "mocha": "^4.0.1",
     "nyc": "^11.3.0",


### PR DESCRIPTION
The package, `log-driver`, should be whitelisted. See
https://github.com/googleapis/nodejs-common/issues/16.
