### PR TITLE
Support Stream constructor options in pagination methods.

### DIFF
--- a/src/paginator.js
+++ b/src/paginator.js
@@ -107,7 +107,6 @@ paginator.parseArguments_ = function(args) {
   var autoPaginate = true;
   var maxApiCalls = -1;
   var maxResults = -1;
-  var streamOptions;
   var callback;
 
   var firstArgument = args[0];
@@ -159,7 +158,6 @@ paginator.parseArguments_ = function(args) {
 
   parsedArguments.streamOptions = extend(true, {}, parsedArguments.query);
   delete parsedArguments.streamOptions.autoPaginate;
-  delete parsedArguments.streamOptions.maxApiCalls;
   delete parsedArguments.streamOptions.maxResults;
   delete parsedArguments.streamOptions.pageSize;
 

--- a/src/paginator.js
+++ b/src/paginator.js
@@ -107,6 +107,7 @@ paginator.parseArguments_ = function(args) {
   var autoPaginate = true;
   var maxApiCalls = -1;
   var maxResults = -1;
+  var streamOptions;
   var callback;
 
   var firstArgument = args[0];
@@ -148,13 +149,21 @@ paginator.parseArguments_ = function(args) {
     }
   }
 
-  return {
+  var parsedArguments = {
     query: query || {},
     autoPaginate: autoPaginate,
     maxApiCalls: maxApiCalls,
     maxResults: maxResults,
     callback: callback,
   };
+
+  parsedArguments.streamOptions = extend(true, {}, parsedArguments.query);
+  delete parsedArguments.streamOptions.autoPaginate;
+  delete parsedArguments.streamOptions.maxApiCalls;
+  delete parsedArguments.streamOptions.maxResults;
+  delete parsedArguments.streamOptions.pageSize;
+
+  return parsedArguments;
 };
 
 /**
@@ -215,6 +224,7 @@ paginator.runAsStream_ = function(parsedArguments, originalMethod) {
 
   var limiter = util.createLimiter(makeRequest, {
     maxApiCalls: parsedArguments.maxApiCalls,
+    streamOptions: parsedArguments.streamOptions,
   });
 
   var stream = limiter.stream;

--- a/src/util.js
+++ b/src/util.js
@@ -635,14 +635,16 @@ util.normalizeArguments = normalizeArguments;
  * @param {object=} options - Configuration object.
  * @param {number} options.maxApiCalls - The maximum number of API calls to
  *     make.
+ * @param {object} options.streamOptions - Options to pass to the Stream
+ *     constructor.
  */
 function createLimiter(makeRequestFn, options) {
-  var stream = streamEvents(through.obj());
+  options = options || {};
+
+  var stream = streamEvents(through.obj(options.streamOptions));
 
   var requestsMade = 0;
   var requestsToMake = -1;
-
-  options = options || {};
 
   if (is.number(options.maxApiCalls)) {
     requestsToMake = options.maxApiCalls;

--- a/test/paginator.js
+++ b/test/paginator.js
@@ -342,6 +342,16 @@ describe('paginator', function() {
 
       assert.strictEqual(parsedArguments.autoPaginate, false);
     });
+
+    it('should parse streamOptions', function() {
+      var args = [{maxResults: 10, highWaterMark: 8}];
+      var parsedArguments = paginator.parseArguments_(args);
+
+      assert.strictEqual(parsedArguments.maxResults, 10);
+      assert.deepStrictEqual(parsedArguments.streamOptions, {
+        highWaterMark: 8,
+      });
+    });
   });
 
   describe('run_', function() {
@@ -520,6 +530,32 @@ describe('paginator', function() {
         };
 
         paginator.runAsStream_({maxApiCalls: maxApiCalls}, util.noop);
+      });
+    });
+
+    describe('streamOptions', function() {
+      var streamOptions = {
+        highWaterMark: 8,
+      };
+
+      it('should pass through stream options', function(done) {
+        overrides.util.createLimiter = function(makeRequest, options) {
+          assert.strictEqual(options.streamOptions, streamOptions);
+
+          setImmediate(done);
+
+          return {
+            stream: through.obj(),
+          };
+        };
+
+        paginator.runAsStream_(
+          {
+            maxApiCalls: 100,
+            streamOptions: streamOptions,
+          },
+          util.noop
+        );
       });
     });
 

--- a/test/util.js
+++ b/test/util.js
@@ -1543,7 +1543,11 @@ describe('common/util', function() {
 
   describe('createLimiter', function() {
     function REQUEST_FN() {}
-    var OPTIONS = {};
+    var OPTIONS = {
+      streamOptions: {
+        highWaterMark: 8,
+      },
+    };
 
     it('should create an object stream with stream-events', function(done) {
       streamEventsOverride = function(stream) {
@@ -1569,6 +1573,15 @@ describe('common/util', function() {
 
       var limiter = util.createLimiter(REQUEST_FN, OPTIONS);
       assert.strictEqual(limiter.stream, streamEventsStream);
+    });
+
+    it('should pass stream options to through', function() {
+      var limiter = util.createLimiter(REQUEST_FN, OPTIONS);
+
+      assert.strictEqual(
+        limiter.stream._readableState.highWaterMark,
+        OPTIONS.streamOptions.highWaterMark
+      );
     });
 
     describe('makeRequest', function() {


### PR DESCRIPTION
Fixes #24

This will allow all paginated streaming methods in the various `@google-cloud/*` libraries to customize the stream options, most popularly "highWaterMark" (used to control backpressure).