### PR TITLE
Do not allow the project ID token to be sent to google-auto-auth.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -330,7 +330,13 @@ util.shouldRetryRequest = shouldRetryRequest;
 function makeAuthenticatedRequestFactory(config) {
   config = config || {};
 
-  var authClient = googleAuth(config);
+  var googleAutoAuthConfig = extend({}, config);
+
+  if (googleAutoAuthConfig.projectId === '{{projectId}}') {
+    delete googleAutoAuthConfig.projectId;
+  }
+
+  var authClient = googleAuth(googleAutoAuthConfig);
 
   /**
    * The returned function that will make an authenticated request.

--- a/test/util.js
+++ b/test/util.js
@@ -689,6 +689,19 @@ describe('common/util', function() {
 
       googleAutoAuthOverride = function(config_) {
         assert.strictEqual(config_.projectId, undefined);
+        setImmediate(done);
+        return authClient;
+      };
+
+      util.makeAuthenticatedRequestFactory(config);
+    });
+
+    it('should not remove projectId from config object', function(done) {
+      var config = {
+        projectId: '{{projectId}}',
+      };
+
+      googleAutoAuthOverride = function(config_) {
         assert.strictEqual(config.projectId, '{{projectId}}');
         setImmediate(done);
         return authClient;

--- a/test/util.js
+++ b/test/util.js
@@ -701,7 +701,7 @@ describe('common/util', function() {
         projectId: '{{projectId}}',
       };
 
-      googleAutoAuthOverride = function(config_) {
+      googleAutoAuthOverride = function() {
         assert.strictEqual(config.projectId, '{{projectId}}');
         setImmediate(done);
         return authClient;

--- a/test/util.js
+++ b/test/util.js
@@ -669,10 +669,27 @@ describe('common/util', function() {
     });
 
     it('should create an authClient', function(done) {
-      var config = {};
+      var config = {
+        test: true,
+      };
 
       googleAutoAuthOverride = function(config_) {
-        assert.strictEqual(config_, config);
+        assert.deepStrictEqual(config_, config);
+        setImmediate(done);
+        return authClient;
+      };
+
+      util.makeAuthenticatedRequestFactory(config);
+    });
+
+    it('should not pass projectId token to google-auto-auth', function(done) {
+      var config = {
+        projectId: '{{projectId}}',
+      };
+
+      googleAutoAuthOverride = function(config_) {
+        assert.strictEqual(config_.projectId, undefined);
+        assert.strictEqual(config.projectId, '{{projectId}}');
         setImmediate(done);
         return authClient;
       };


### PR DESCRIPTION
Fixes #31 

This will block google-auto-auth from receiving `{{projectId}}`, which it assumes is the user's project ID.