### PR TITLE
fix: pin log-driver to 1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "extend": "^3.0.1",
     "google-auto-auth": "^0.9.0",
     "is": "^3.2.0",
-    "log-driver": "^1.2.5",
+    "log-driver": "1.2.5",
     "methmeth": "^1.1.0",
     "modelo": "^4.2.0",
     "request": "^2.79.0",


### PR DESCRIPTION
The first time this year where greenkeeper CI check proved useful.