### PR TITLE
style: fix prettier incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "mocha": "^5.0.0",
     "nyc": "^11.3.0",
     "power-assert": "^1.4.4",
-    "prettier": "^1.8.1",
+    "prettier": "^1.11.1",
     "proxyquire": "^1.7.10",
     "uuid": "^3.0.1"
   }

--- a/src/service-object.js
+++ b/src/service-object.js
@@ -77,12 +77,14 @@ function ServiceObject(config) {
     var allMethodNames = Object.keys(ServiceObject.prototype);
     allMethodNames
       .filter(function(methodName) {
-        return (// All ServiceObjects need `request`.
+        return (
+          // All ServiceObjects need `request`.
           !/^request/.test(methodName) &&
           // The ServiceObject didn't redefine the method.
           self[methodName] === ServiceObject.prototype[methodName] &&
           // This method isn't wanted.
-          !config.methods[methodName] );
+          !config.methods[methodName]
+        );
       })
       .forEach(function(methodName) {
         self[methodName] = undefined;


### PR DESCRIPTION
Looks like the latest prettier update introduced incompatibility. Fixing the code formatting to make prettier happy, and updating the required version in `package.json`.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
