### PR TITLE
chore: run appveyor on node8 only

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: 4
-  - nodejs_version: 6
-  - nodejs_version: 7
   - nodejs_version: 8
 
 install:


### PR DESCRIPTION
We don't run it on node4, 6, 7 for other libraries, no reason to do it in this library as well.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
