### PR TITLE
chore: delete js-green-licenses.json

### DIFF
--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -1,5 +1,0 @@
-{
-  "packageWhitelist": [
-    "log-driver"  // https://github.com/googleapis/nodejs-common/issues/16
-  ]
-}


### PR DESCRIPTION
`log-driver` has no license issues anymore.
