### PR TITLE
Support access token

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -62,6 +62,7 @@ function Service(config, options) {
     credentials: options.credentials,
     keyFile: options.keyFilename,
     email: options.email,
+    token: options.token,
   });
 
   this.makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(reqCfg);

--- a/test/service.js
+++ b/test/service.js
@@ -52,6 +52,7 @@ describe('Service', function() {
     keyFile: {},
     email: 'email',
     projectId: 'project-id',
+    token: 'token',
   };
 
   before(function() {
@@ -82,6 +83,7 @@ describe('Service', function() {
           email: OPTIONS.email,
           projectIdRequired: CONFIG.projectIdRequired,
           projectId: OPTIONS.projectId,
+          token: OPTIONS.token,
         });
 
         assert.deepEqual(config, expectedConfig);


### PR DESCRIPTION
Fixes #11 

This will allow a user to provide an access token, which will then be used by google-auto-auth.