### PR TITLE
chore: setup nighty build in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,8 @@
-unit_tests:
-  steps: &unit_tests
-    - checkout
-    - run:
-        name: Install modules and dependencies.
-        command: npm install
-    - run:
-        name: Run unit tests.
-        command: npm test
-    - run:
-        name: Submit coverage data to codecov.
-        command: node_modules/.bin/codecov
-        when: always
 version: 2
 workflows:
   version: 2
   tests:
-    jobs:
+    jobs: &workflow_jobs
       - node4:
           filters:
             tags:
@@ -59,15 +46,34 @@ workflows:
               ignore: /.*/
             tags:
               only: '/^v[\d.]+$/'
+  nightly:
+    triggers:
+      - schedule:
+          cron: 0 7 * * *
+          filters:
+            branches:
+              only: master
+    jobs: *workflow_jobs
 jobs:
   node4:
     docker:
       - image: 'node:4'
-    steps:
+    steps: &unit_tests_steps
       - checkout
+      - run: &remove_package_lock
+          name: Remove package-lock.json if needed.
+          command: |
+            WORKFLOW_NAME=`python .circleci/get_workflow_name.py`
+            echo "Workflow name: $WORKFLOW_NAME"
+            if [ "$WORKFLOW_NAME" = "nightly" ]; then
+              echo "Nightly build detected, removing package-lock.json."
+              rm -f package-lock.json samples/package-lock.json
+            else
+              echo "Not a nightly build, skipping this step."
+            fi
       - run:
           name: Install modules and dependencies.
-          command: npm install --unsafe-perm
+          command: npm install
       - run:
           name: Run unit tests.
           command: npm test
@@ -78,20 +84,21 @@ jobs:
   node6:
     docker:
       - image: 'node:6'
-    steps: *unit_tests
+    steps: *unit_tests_steps
   node8:
     docker:
       - image: 'node:8'
-    steps: *unit_tests
+    steps: *unit_tests_steps
   node9:
     docker:
       - image: 'node:9'
-    steps: *unit_tests
+    steps: *unit_tests_steps
   lint:
     docker:
       - image: 'node:8'
     steps:
       - checkout
+      - run: *remove_package_lock
       - run:
           name: Install modules and dependencies.
           command: npm install
@@ -103,6 +110,7 @@ jobs:
       - image: 'node:8'
     steps:
       - checkout
+      - run: *remove_package_lock
       - run:
           name: Install modules and dependencies.
           command: npm install

--- a/.circleci/get_workflow_name.py
+++ b/.circleci/get_workflow_name.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Get workflow name for the current build using CircleCI API.
+Would be great if this information is available in one of
+CircleCI environment variables, but it's not there.
+https://circleci.ideas.aha.io/ideas/CCI-I-295
+"""
+
+import json
+import os
+import sys
+import urllib2
+
+
+def main():
+    try:
+        username = os.environ['CIRCLE_PROJECT_USERNAME']
+        reponame = os.environ['CIRCLE_PROJECT_REPONAME']
+        build_num = os.environ['CIRCLE_BUILD_NUM']
+    except:
+        sys.stderr.write(
+            'Looks like we are not inside CircleCI container. Exiting...\n')
+        return 1
+
+    try:
+        request = urllib2.Request(
+            "https://circleci.com/api/v1.1/project/github/%s/%s/%s" %
+            (username, reponame, build_num),
+            headers={"Accept": "application/json"})
+        contents = urllib2.urlopen(request).read()
+    except:
+        sys.stderr.write('Cannot query CircleCI API. Exiting...\n')
+        return 1
+
+    try:
+        build_info = json.loads(contents)
+    except:
+        sys.stderr.write(
+            'Cannot parse JSON received from CircleCI API. Exiting...\n')
+        return 1
+
+    try:
+        workflow_name = build_info['workflows']['workflow_name']
+    except:
+        sys.stderr.write(
+            'Cannot get workflow name from CircleCI build info. Exiting...\n')
+        return 1
+
+    print workflow_name
+    return 0
+
+
+retval = main()
+exit(retval)


### PR DESCRIPTION
Creating a new workflow called `nightly` that will run every night. It will remove `package-lock.json`, then run the build.