### PR TITLE
chore: remove through2

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "request": "^2.85.0",
     "retry-request": "^3.3.1",
     "split-array-stream": "^2.0.0",
-    "stream-events": "^1.0.3",
-    "through2": "^2.0.3"
+    "stream-events": "^1.0.3"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.2.6",
@@ -100,6 +99,7 @@
     "proxyquire": "^2.0.1",
     "sinon": "^4.5.0",
     "source-map-support": "^0.5.4",
+    "through2": "^2.0.3",
     "typescript": "^2.8.1",
     "uuid": "^3.2.1"
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,8 +24,7 @@ import * as extend from 'extend';
 import * as is from 'is';
 import * as r from 'request';
 import * as retryRequest from 'retry-request';
-import * as through from 'through2';
-import { Duplex, Stream } from 'stream';
+import { Duplex, Transform, Stream } from 'stream';
 import * as streamEvents from 'stream-events';
 const googleAuth = require('google-auto-auth');
 
@@ -260,7 +259,7 @@ interface MakeWritableStreamOptions {
 function makeWritableStream(dup: duplexify.Duplexify, options: MakeWritableStreamOptions, onComplete: Function) {
   onComplete = onComplete || util.noop;
 
-  const writeStream = through();
+  const writeStream = new Transform();
   dup.setWritable(writeStream);
 
   const defaultReqOpts = {
@@ -768,7 +767,9 @@ interface CreateLimiterOptions {
 function createLimiter(makeRequestFn: Function, options?: CreateLimiterOptions) {
   options = options || {};
 
-  const stream = streamEvents(through.obj(options.streamOptions));
+  const streamOptions = options.streamOptions || {};
+  streamOptions.objectMode = true;
+  const stream = streamEvents(new Transform(streamOptions));
 
   let requestsMade = 0;
   let requestsToMake = -1;


### PR DESCRIPTION
I ain't no expert in nodejs streams. But at a glance, it didn't look like we really needed `through2` in the mix here.  What do y'all think?  Does this PR pretty much do what through2 was doing for us? 
