### PR TITLE
chore: remove concat-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "arrify": "^1.0.1",
-    "concat-stream": "^1.6.2",
     "duplexify": "^3.5.4",
     "ent": "^2.2.0",
     "extend": "^3.0.1",
@@ -69,7 +68,6 @@
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.2.6",
     "@types/arrify": "^1.0.3",
-    "@types/concat-stream": "^1.6.0",
     "@types/duplexify": "^3.5.0",
     "@types/ent": "^2.2.1",
     "@types/extend": "^3.0.0",

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -183,22 +183,11 @@ export class Paginator {
     const autoPaginate = parsedArguments.autoPaginate;
 
     if (autoPaginate) {
-      const results = new Array<any>();
+      const results = new Array<{}>();
       paginator.runAsStream_(parsedArguments, originalMethod)
         .on('error', callback)
         .on('data', data => results.push(data))
-        .on('end', () => {
-          if (results.length > 0) {
-            if (typeof results[0] === 'string') {
-              return callback(null, results.join(''));
-            } else if (results[0] instanceof Buffer) {
-              return callback(null, Buffer.concat(results))
-            } else if (Array.isArray(results[0])) {
-              return callback(null, [].concat.apply([], results));
-            }
-          }
-          callback(null, results);
-        });
+        .on('end', () => callback(null, results));
     } else {
       originalMethod(query, callback);
     }

--- a/test/paginator.ts
+++ b/test/paginator.ts
@@ -349,27 +349,22 @@ describe('paginator', () => {
       });
 
       it('should return all results on end', (done) => {
-        const results = ['a', 'b', 'c'];
+        const results = [{a: 1}, {b: 2}, {c: 3}];
 
         const parsedArguments = {
           autoPaginate: true,
           callback(err, results_) {
-            assert.deepEqual(results_.toString().split(''), results);
+            assert.deepStrictEqual(results_, results);
             done();
           },
         };
 
         stub('runAsStream_', () => {
-          const stream = through();
-
+          const stream = through.obj();
           setImmediate(() => {
-            results.forEach((result) => {
-              stream.push(result);
-            });
-
+            results.forEach(result => stream.push(result));
             stream.push(null);
           });
-
           return stream;
         });
 


### PR DESCRIPTION
I'm just playing around with reducing our dependency graph.  I think I covered most of the useful stuff concat-stream was doing 🤷‍♂️ 

@stephenplusplus - do you know what kind of data these streams typically handle?  The tests just send through buffers, but it looks like concat-stream does a fair bit with type checking.  It would be super rad to know what exactly this does to make sure I ain't breaking it ⚒ 