### PR TITLE
fix: expose LoggerConfig and ServiceConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-// Logger is new in 0.18.0.
 export {GoogleAuthOptions} from 'google-auth-library';
-export {Logger} from './logger';
+
+// Logger is new in 0.18.0.
+export {Logger, LoggerConfig} from './logger';
 // logger is the interface exported prior to 0.18.0. The two logging-related
 // interfaces are not mutually compatible, though the implementation
 // of logger is currently a wrapper around Logger.
@@ -37,7 +38,7 @@ export {paginator} from './paginator';
  * @type {module:common/service}
  * @private
  */
-export {Service} from './service';
+export {Service, ServiceConfig} from './service';
 /**
  * @type {module:common/serviceObject}
  * @private

--- a/src/logger-compat.ts
+++ b/src/logger-compat.ts
@@ -20,21 +20,21 @@
 
 import * as is from 'is';
 
-import {kFormat, Logger, LoggerOptions} from './logger';
+import {kFormat, Logger, LoggerConfig} from './logger';
 
 // tslint:disable-next-line:no-any
 function isString(obj: any): obj is string {
   return is.string(obj);
 }
 
-function createLogger(optionsOrLevel?: Partial<LoggerOptions>|string) {
+function createLogger(optionsOrLevel?: Partial<LoggerConfig>|string) {
   // Canonicalize input.
   if (isString(optionsOrLevel)) {
     optionsOrLevel = {
       level: optionsOrLevel,
     };
   }
-  const options: LoggerOptions =
+  const options: LoggerConfig =
       Object.assign({}, Logger.DEFAULT_OPTIONS, optionsOrLevel);
   const result = new Logger(options);
   Object.defineProperty(result, 'format', {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,7 +18,7 @@
  * @module common/logger
  */
 
-export interface LoggerOptions {
+export interface LoggerConfig {
   /**
    * The minimum log level that will print to the console.
    */
@@ -51,7 +51,7 @@ export class Logger {
    * Default logger options.
    */
   static DEFAULT_OPTIONS:
-      Readonly<LoggerOptions> = {level: 'error', levels: LEVELS, tag: ''};
+      Readonly<LoggerConfig> = {level: 'error', levels: LEVELS, tag: ''};
 
   // TODO: Mark this private when TypeScript 2.9 comes out.
   // See https://github.com/Microsoft/TypeScript/issues/20080 for more
@@ -67,8 +67,8 @@ export class Logger {
   /**
    * Create a logger to print output to the console.
    */
-  constructor(opts?: Partial<LoggerOptions>) {
-    const options: LoggerOptions =
+  constructor(opts?: Partial<LoggerConfig>) {
+    const options: LoggerConfig =
         Object.assign({}, Logger.DEFAULT_OPTIONS, opts);
     this[kTag] = options.tag ? ':' + options.tag + ':' : '';
 

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import * as shimmer from 'shimmer';
 
 import * as loggerModule from '../src/logger';
-import {kFormat, kTag, Logger, LoggerOptions} from '../src/logger';
+import {kFormat, kTag, Logger, LoggerConfig} from '../src/logger';
 import {logger} from '../src/logger-compat';
 
 const LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
@@ -131,12 +131,12 @@ describe('logger', () => {
     [kFormat](level: string, ...args: any[]): string {
       return 'foo';
     }
-    constructor(options: Partial<LoggerOptions>) {
+    constructor(options: Partial<LoggerConfig>) {
       capturedOptions = options;
     }
   }
 
-  let capturedOptions: Partial<LoggerOptions>|null = null;
+  let capturedOptions: Partial<LoggerConfig>|null = null;
 
   before(() => {
     shimmer.wrap(loggerModule, 'Logger', () => FakeLogger);


### PR DESCRIPTION
This PR changes `LoggerOptions` to `LoggerConfig` and exposes it. `ServiceConfig` is exposed as well. This allows us to obtain the types need to construct these objects.