### PR TITLE
feat: remove `levels` from LoggerConfig and don't expose index property on Logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@
 export {GoogleAuthOptions} from 'google-auth-library';
 
 // Logger is new in 0.18.0.
-export {Logger, LoggerConfig} from './logger';
+export {CustomLevelsLogger, Logger, LoggerConfig} from './logger';
 // logger is the interface exported prior to 0.18.0. The two logging-related
 // interfaces are not mutually compatible, though the implementation
 // of logger is currently a wrapper around Logger.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,13 @@
 export {GoogleAuthOptions} from 'google-auth-library';
 
 // Logger is new in 0.18.0.
-export {CustomLevelsLogger, Logger, LoggerConfig} from './logger';
+export {Logger, LoggerConfig} from './logger';
 // logger is the interface exported prior to 0.18.0. The two logging-related
 // interfaces are not mutually compatible, though the implementation
 // of logger is currently a wrapper around Logger.
 // TODO: logger should eventually be deprecated.
-export {logger} from './logger-compat';
+export {CustomLevelsLoggerConfig, CustomLevelsLoggerResult, logger} from './logger-compat';
+
 /**
  * @type {module:common/operation}
  * @private

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,15 +15,13 @@
  */
 
 export {GoogleAuthOptions} from 'google-auth-library';
-
 // Logger is new in 0.18.0.
 export {Logger, LoggerConfig} from './logger';
 // logger is the interface exported prior to 0.18.0. The two logging-related
 // interfaces are not mutually compatible, though the implementation
 // of logger is currently a wrapper around Logger.
 // TODO: logger should eventually be deprecated.
-export {CustomLevelsLoggerConfig, CustomLevelsLoggerResult, logger} from './logger-compat';
-
+export {CustomLevelsLogger, CustomLevelsLoggerConfig, logger} from './logger-compat';
 /**
  * @type {module:common/operation}
  * @private

--- a/src/logger-compat.ts
+++ b/src/logger-compat.ts
@@ -20,7 +20,7 @@
 
 import * as is from 'is';
 
-import {kFormat, Logger, LoggerConfig} from './logger';
+import {CustomLevelsLogger, kFormat, Logger, LoggerConfig} from './logger';
 
 // tslint:disable-next-line:no-any
 function isString(obj: any): obj is string {
@@ -48,7 +48,7 @@ function createLogger(optionsOrLevel?: Partial<LoggerConfig>|string) {
   });
   return Object.assign(
       // tslint:disable-next-line:no-any
-      result as Logger & {format: (...args: any[]) => string},
+      result as CustomLevelsLogger & {format: (...args: any[]) => string},
       {levels: options.levels, level: options.level});
 }
 

--- a/src/logger-compat.ts
+++ b/src/logger-compat.ts
@@ -20,23 +20,43 @@
 
 import * as is from 'is';
 
-import {CustomLevelsLogger, kFormat, Logger, LoggerConfig} from './logger';
+import {kFormat, LEVELS, Logger, LoggerConfig} from './logger';
+
+export interface CustomLevelsLoggerConfig extends LoggerConfig {
+  /**
+   * The list of levels to use.
+   */
+  levels: string[];
+}
+
+// tslint:disable:no-any
+export type CustomLevelsLoggerResult = {
+  [logLevel: string]: (...args: any[]) => CustomLevelsLoggerResult;
+}&{
+  format: (...args: any[]) => string;
+  levels: string[];
+  level: string|false;
+};
+// tslint:enable:no-any
 
 // tslint:disable-next-line:no-any
 function isString(obj: any): obj is string {
   return is.string(obj);
 }
 
-function createLogger(optionsOrLevel?: Partial<LoggerConfig>|string) {
+function createLogger(optionsOrLevel?: Partial<CustomLevelsLoggerConfig>|
+                      string): CustomLevelsLoggerResult {
   // Canonicalize input.
   if (isString(optionsOrLevel)) {
     optionsOrLevel = {
       level: optionsOrLevel,
     };
   }
-  const options: LoggerConfig =
-      Object.assign({}, Logger.DEFAULT_OPTIONS, optionsOrLevel);
-  const result = new Logger(options);
+  const options: CustomLevelsLoggerConfig =
+      Object.assign({levels: LEVELS}, Logger.DEFAULT_OPTIONS, optionsOrLevel);
+  // ts: We construct other fields on result after its declaration.
+  // tslint:disable-next-line:no-any
+  const result: CustomLevelsLoggerResult = new Logger(options) as any;
   Object.defineProperty(result, 'format', {
     get() {
       return result[kFormat];
@@ -46,13 +66,8 @@ function createLogger(optionsOrLevel?: Partial<LoggerConfig>|string) {
       result[kFormat] = value.bind(result);
     }
   });
-  return Object.assign(
-      // tslint:disable-next-line:no-any
-      result as CustomLevelsLogger & {format: (...args: any[]) => string},
-      {levels: options.levels, level: options.level});
+  return Object.assign(result, {levels: options.levels, level: options.level});
 }
-
-const LEVELS = Logger.DEFAULT_OPTIONS.levels;
 
 /**
  * Create a logger to print output to the console.

--- a/src/logger-compat.ts
+++ b/src/logger-compat.ts
@@ -30,8 +30,8 @@ export interface CustomLevelsLoggerConfig extends LoggerConfig {
 }
 
 // tslint:disable:no-any
-export type CustomLevelsLoggerResult = {
-  [logLevel: string]: (...args: any[]) => CustomLevelsLoggerResult;
+export type CustomLevelsLogger = {
+  [logLevel: string]: (...args: any[]) => CustomLevelsLogger;
 }&{
   format: (...args: any[]) => string;
   levels: string[];
@@ -45,7 +45,7 @@ function isString(obj: any): obj is string {
 }
 
 function createLogger(optionsOrLevel?: Partial<CustomLevelsLoggerConfig>|
-                      string): CustomLevelsLoggerResult {
+                      string): CustomLevelsLogger {
   // Canonicalize input.
   if (isString(optionsOrLevel)) {
     optionsOrLevel = {
@@ -56,7 +56,7 @@ function createLogger(optionsOrLevel?: Partial<CustomLevelsLoggerConfig>|
       Object.assign({levels: LEVELS}, Logger.DEFAULT_OPTIONS, optionsOrLevel);
   // ts: We construct other fields on result after its declaration.
   // tslint:disable-next-line:no-any
-  const result: CustomLevelsLoggerResult = new Logger(options) as any;
+  const result: CustomLevelsLogger = new Logger(options) as any;
   Object.defineProperty(result, 'format', {
     get() {
       return result[kFormat];

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -58,6 +58,9 @@ export class Logger {
 
   private[kTag]: string;
 
+  // ts: The compiler can't statically detect that these will be definitely
+  // assigned. They will be if default log levels are used, so we use non-null
+  // annotations here.
   // tslint:disable:no-any
   silent!: (...args: any[]) => this;
   error!: (...args: any[]) => this;
@@ -91,7 +94,7 @@ export class Logger {
     for (let i = 0; i < options.levels.length; i++) {
       const level = options.levels[i];
       if (i <= levelIndex) {
-        // ts: this doesn't have an index signature, but we want to set
+        // ts: This doesn't have an index signature, but we want to set
         // properties anyway.
         // tslint:disable-next-line:no-any
         (this as any)[level] = (...args: any[]) => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -28,11 +28,6 @@ export interface LoggerConfig {
   level: string|false;
 
   /**
-   * The list of levels to use.
-   */
-  levels: string[];
-
-  /**
    * A tag to use in log messages.
    */
   tag: string;
@@ -41,7 +36,7 @@ export interface LoggerConfig {
 /**
  * The default list of log levels.
  */
-const LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
+export const LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
 
 export const kFormat = Symbol('Logger formatter');
 export const kTag = Symbol('Logger tag format');
@@ -53,14 +48,12 @@ export class Logger {
   /**
    * Default logger options.
    */
-  static DEFAULT_OPTIONS:
-      Readonly<LoggerConfig> = {level: 'error', levels: LEVELS, tag: ''};
+  static DEFAULT_OPTIONS: Readonly<LoggerConfig> = {level: 'error', tag: ''};
 
   private[kTag]: string;
 
   // ts: The compiler can't statically detect that these will be definitely
-  // assigned. They will be if default log levels are used, so we use non-null
-  // annotations here.
+  // assigned, so we use non-null annotations here.
   // tslint:disable:no-any
   silent!: (...args: any[]) => this;
   error!: (...args: any[]) => this;
@@ -78,21 +71,25 @@ export class Logger {
         Object.assign({}, Logger.DEFAULT_OPTIONS, opts);
     this[kTag] = options.tag ? ':' + options.tag + ':' : '';
 
+    // Get the list of levels.
+    // This is undocumented behavior and subject to change.
+    const levels = (options as {levels?: string[]}).levels || LEVELS;
+
     // Determine lowest log level.
     // If the given level is set to false, don't log anything.
     let levelIndex = -1;
     if (options.level !== false) {
-      levelIndex = options.level ? options.levels.indexOf(options.level) :
-                                   options.levels.length - 1;
+      levelIndex =
+          options.level ? levels.indexOf(options.level) : levels.length - 1;
       if (levelIndex === -1) {
         throw new Error(`Logger: options.level [${
-            options.level}] is not one of options.levels [${
-            options.levels.join(', ')}]`);
+            options.level}] is not one of available levels [${
+            levels.join(', ')}]`);
       }
     }
 
-    for (let i = 0; i < options.levels.length; i++) {
-      const level = options.levels[i];
+    for (let i = 0; i < levels.length; i++) {
+      const level = levels[i];
       if (i <= levelIndex) {
         // ts: This doesn't have an index signature, but we want to set
         // properties anyway.
@@ -115,14 +112,4 @@ export class Logger {
     const message = args.join(' ');
     return `${level}${this[kTag]} ${message}`;
   }
-}
-
-/**
- * A type to which a Logger instance can be casted, which defines additional
- * custom log levels on the Logger instance.
- * Ex: `const l = new Logger() as CustomLevelsLogger;`
- */
-export interface CustomLevelsLogger extends Logger {
-  // tslint:disable-next-line:no-any
-  [logLevel: string]: (...args: any[]) => this;
 }

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -18,12 +18,13 @@ import * as assert from 'assert';
 import * as shimmer from 'shimmer';
 
 import * as loggerModule from '../src/logger';
-import {CustomLevelsLogger, Logger, LoggerConfig} from '../src/logger';
-import {logger} from '../src/logger-compat';
+import {Logger, LoggerConfig} from '../src/logger';
+import {CustomLevelsLoggerConfig, logger} from '../src/logger-compat';
 
-const LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
+const LEVELS: Array<'silent'|'error'|'warn'|'info'|'debug'|'silly'> =
+    ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
 
-describe('Logger', () => {
+describe('logging', () => {
   function getHighestLogLevel(lines: string[], levels: string[]) {
     const index = lines.reduce((highestLogLevel, line) => {
       return Math.max(
@@ -36,7 +37,6 @@ describe('Logger', () => {
     throw new Error('No logs with expected format was found');
   }
 
-  const customLevels = ['level-1', 'level-2', 'level-3'];
   const lines: string[] = [];
 
   before(() => {
@@ -53,135 +53,118 @@ describe('Logger', () => {
     shimmer.unwrap(console, 'log');
   });
 
-  it('should create a logger based on default config parameters', () => {
-    const logger = new Logger() as CustomLevelsLogger;
-    for (const level of LEVELS) {
-      assert.strictEqual(typeof logger[level], 'function');
-    }
-    logger.error('an error!');
-    logger.warn('a warning?');
-    assert.strictEqual(getHighestLogLevel(lines, LEVELS), 'error');
-  });
-
-  it('should create a logger with custom levels', () => {
-    const logger =
-        new Logger({level: false, levels: customLevels}) as CustomLevelsLogger;
-    for (const customLevel of customLevels) {
-      assert.strictEqual(typeof logger[customLevel], 'function');
-    }
-    for (const level of LEVELS) {
-      assert.strictEqual(typeof logger[level], 'undefined');
-    }
-  });
-
-  it('can chain log calls', () => {
-    const logger = new Logger({level: 'info'});
-    logger.error('hi').warn('bye');
-    assert.strictEqual(getHighestLogLevel(lines, LEVELS), 'warn');
-  });
-
-  it('should use a specified level', () => {
-    const level = 'level-2';
-    const logger =
-        new Logger({level, levels: customLevels}) as CustomLevelsLogger;
-    for (const customLevel of customLevels) {
-      logger[customLevel]('foo');
-    }
-    assert.strictEqual(getHighestLogLevel(lines, customLevels), level);
-  });
-
-  it('should not log if level is false', () => {
-    const logger =
-        new Logger({level: false, levels: customLevels}) as CustomLevelsLogger;
-    for (const customLevel of customLevels) {
-      logger[customLevel]('foo');
-    }
-    assert.throws(() => getHighestLogLevel(lines, customLevels));
-  });
-
-  it('should throw when specified opts.level is not in opts.levels', () => {
-    const level = 'not-a-level';
-    assert.throws(() => new Logger({level}));
-  });
-
-  describe('formatting', () => {
-    const TAG = 'tag-name';
-    const MESSAGES = ['message-1', 'message-2'];
-
-    it('should correctly format without a tag', () => {
-      new Logger().error(MESSAGES[0], MESSAGES[1]);
-      assert.strictEqual(lines.length, 1);
-      assert.strictEqual(lines[0], 'ERROR message-1 message-2');
+  describe('Logger', () => {
+    it('should create a logger based on default config parameters', () => {
+      const logger = new Logger();
+      for (const level of LEVELS) {
+        assert.strictEqual(typeof logger[level], 'function');
+      }
+      logger.error('an error!');
+      logger.warn('a warning?');
+      assert.strictEqual(getHighestLogLevel(lines, LEVELS), 'error');
     });
 
-    it('should correctly format with a tag', () => {
-      new Logger({
-        tag: TAG,
-      }).error(MESSAGES[0], MESSAGES[1]);
-      assert.strictEqual(lines.length, 1);
-      assert.strictEqual(lines[0], 'ERROR:tag-name: message-1 message-2');
+    it('can chain log calls', () => {
+      const logger = new Logger({level: 'info'});
+      logger.error('hi').warn('bye');
+      assert.strictEqual(getHighestLogLevel(lines, LEVELS), 'warn');
+    });
+
+    it('should not log if level is false', () => {
+      const logger = new Logger({level: false});
+      for (const level of LEVELS) {
+        logger[level]('foo');
+      }
+      assert.throws(() => getHighestLogLevel(lines, LEVELS));
+    });
+
+    it('should throw when specified opts.level is not in opts.levels', () => {
+      const level = 'not-a-level';
+      assert.throws(() => new Logger({level}));
+    });
+
+    describe('formatting', () => {
+      const TAG = 'tag-name';
+      const MESSAGES = ['message-1', 'message-2'];
+
+      it('should correctly format without a tag', () => {
+        new Logger().error(MESSAGES[0], MESSAGES[1]);
+        assert.strictEqual(lines.length, 1);
+        assert.strictEqual(lines[0], 'ERROR message-1 message-2');
+      });
+
+      it('should correctly format with a tag', () => {
+        new Logger({
+          tag: TAG,
+        }).error(MESSAGES[0], MESSAGES[1]);
+        assert.strictEqual(lines.length, 1);
+        assert.strictEqual(lines[0], 'ERROR:tag-name: message-1 message-2');
+      });
     });
   });
-});
 
-describe('logger', () => {
-  class FakeLogger extends Logger {
-    static DEFAULT_OPTIONS = Logger.DEFAULT_OPTIONS;
-    constructor(options?: Partial<LoggerConfig>) {
-      super(options);
-      capturedOptions = options!;
-    }
-  }
-
-  let capturedOptions: Partial<LoggerConfig>|null = null;
-
-  before(() => {
-    shimmer.wrap(loggerModule, 'Logger', () => FakeLogger);
-  });
-
-  beforeEach(() => {
-    capturedOptions = null;
-  });
-
-  after(() => {
-    shimmer.unwrap(loggerModule, 'Logger');
-  });
-
-  it('should expose the default list of levels', () => {
-    assert.deepStrictEqual(logger.LEVELS, LEVELS);
-  });
-
-  it('should create a Logger with the correct defaults', () => {
-    assert.ok(logger() instanceof FakeLogger);
-    assert.deepStrictEqual(capturedOptions, Logger.DEFAULT_OPTIONS);
-  });
-
-  it('should expose a predictable interface', () => {
-    const loggerInstance = logger();
-    assert.strictEqual(loggerInstance.levels, capturedOptions!.levels);
-    assert.strictEqual(loggerInstance.level, capturedOptions!.level);
-    assert.strictEqual(loggerInstance.format('hello'), 'HELLO ');
-    loggerInstance.format = function(arg) {
-      return arg + ' ' + typeof this.format;
-    };
-    assert.strictEqual(loggerInstance.format('hello'), 'hello function');
-  });
-
-  it('should create a Logger with custom levels', () => {
+  describe('logger', () => {
     const customLevels = ['level-1', 'level-2', 'level-3'];
-    logger({level: 'level-1', levels: customLevels});
-    assert.deepStrictEqual(capturedOptions!.levels, customLevels);
-  });
 
-  it('should use a specified level', () => {
-    const level = 'silly';
-    logger({level});
-    assert.deepStrictEqual(capturedOptions!.level, level);
-  });
+    it('should expose the default list of levels', () => {
+      assert.deepStrictEqual(logger.LEVELS, LEVELS);
+    });
 
-  it('should treat a single arguments as the level', () => {
-    const level = 'silly';
-    logger(level);
-    assert.deepStrictEqual(capturedOptions!.level, level);
+    it('should create a Logger with the correct defaults', () => {
+      let capturedOptions: Partial<LoggerConfig>|null = null;
+      class FakeLogger extends Logger {
+        static DEFAULT_OPTIONS = Logger.DEFAULT_OPTIONS;
+        constructor(options?: Partial<LoggerConfig>) {
+          super(options);
+          capturedOptions = options!;
+        }
+      }
+      shimmer.wrap(loggerModule, 'Logger', () => FakeLogger);
+      try {
+        assert.ok(logger() instanceof FakeLogger);
+        assert.deepStrictEqual(
+            capturedOptions,
+            Object.assign(Logger.DEFAULT_OPTIONS, {levels: LEVELS}));
+      } finally {
+        shimmer.unwrap(loggerModule, 'Logger');
+      }
+    });
+
+    it('should expose a predictable interface', () => {
+      const loggerInstance =
+          logger({level: customLevels[0], levels: customLevels});
+      assert.strictEqual(loggerInstance.levels, customLevels);
+      assert.strictEqual(loggerInstance.level, customLevels[0]);
+      assert.strictEqual(loggerInstance.format('hello'), 'HELLO ');
+      loggerInstance.format = function(arg) {
+        return arg + ' ' + typeof this.format;
+      };
+      assert.strictEqual(loggerInstance.format('hello'), 'hello function');
+    });
+
+    it('should create a logger with custom levels', () => {
+      const loggerInstance = logger({level: false, levels: customLevels});
+      for (const customLevel of customLevels) {
+        assert.strictEqual(typeof loggerInstance[customLevel], 'function');
+      }
+    });
+
+    it('should use a specified level', () => {
+      const level = 'level-2';
+      const loggerInstance = logger({level, levels: customLevels});
+      for (const customLevel of customLevels) {
+        loggerInstance[customLevel]('foo');
+      }
+      assert.strictEqual(getHighestLogLevel(lines, customLevels), level);
+    });
+
+    it('should treat a single arguments as the level', () => {
+      const level = 'silly';
+      const loggerInstance = logger(level);
+      for (const level of LEVELS) {
+        loggerInstance[level]('foo');
+      }
+      assert.strictEqual(getHighestLogLevel(lines, LEVELS), level);
+    });
   });
 });


### PR DESCRIPTION
__edit:__ _In addition to the below, this PR removes `levels` from the documented API of `LoggerConfig`. There are no behavioral changes here, and impact should overall be minimal because `LoggerConfig` (along with `Logger`) was introduced in 0.18._

This change makes it so that object of type `Logger` by default expose log levels corresponding to the default options. This is the primary use case for objects of type `Logger`.

For `Logger` objects with custom log levels:

```ts
const l = new Logger() as CustomLevelsLogger;
l.baby('foo');
```

This makes mocking `Logger` objects easier, and also gives us code completion for default log levels.