### PR TITLE
Add promisifyAll support for es classes

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1001,10 +1001,8 @@ export class Util {
   // tslint:disable-next-line:variable-name
   promisifyAll(Class: Function, options?: PromisifyAllOptions) {
     const exclude = (options && options.exclude) || [];
-    const allProperties = Object.getOwnPropertyNames ?
-        Object.getOwnPropertyNames(Class.prototype) :
-        Object.keys(Class.prototype);
-    const methods = allProperties.filter((methodName) => {
+    const ownPropertyNames = Object.getOwnPropertyNames(Class.prototype);
+    const methods = ownPropertyNames.filter((methodName) => {
       // clang-format off
       return (
         is.fn(Class.prototype[methodName]) && // is it a function?

--- a/src/util.ts
+++ b/src/util.ts
@@ -1001,11 +1001,14 @@ export class Util {
   // tslint:disable-next-line:variable-name
   promisifyAll(Class: Function, options?: PromisifyAllOptions) {
     const exclude = (options && options.exclude) || [];
-    const methods = Object.keys(Class.prototype).filter((methodName) => {
+    const allProperties = Object.getOwnPropertyNames ?
+        Object.getOwnPropertyNames(Class.prototype) :
+        Object.keys(Class.prototype);
+    const methods = allProperties.filter((methodName) => {
       // clang-format off
       return (
         is.fn(Class.prototype[methodName]) && // is it a function?
-        !/(^_|(Stream|_)|promise$)/.test(methodName) && // is it promisable?
+        !/(^_|(Stream|_)|promise$)|^constructor$/.test(methodName) && // is it promisable?
         exclude.indexOf(methodName) === -1
       ); // is it blacklisted?
       // clang-format on

--- a/test/util.ts
+++ b/test/util.ts
@@ -1753,9 +1753,14 @@ describe('common/util', () => {
       assert.strictEqual(FakeClass.prototype.promise, util.noop);
     });
 
+    // The ts compiler will convert a class to the current node version target,
+    // in this case v4, which means that using the class keyword to create a
+    // class won't actually test that this method works on ES classes. Using
+    // eval works around that compilation. The class syntax is a syntax error
+    // in node v4 which is why the eval call is wrapped in a try catch block.
     try {
       eval(`
-        it('should work on es classes', () => {
+        it('should work on ES classes', () => {
           class MyESClass {
             myMethod(str, callback) {
               callback(str.toUpperCase());
@@ -1766,7 +1771,7 @@ describe('common/util', () => {
         });
       `);
     } catch (error) {
-      it.skip('should work on es classes');
+      it.skip('should work on ES classes');
     }
 
     it('should optionally except an exclude list', () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1753,6 +1753,22 @@ describe('common/util', () => {
       assert.strictEqual(FakeClass.prototype.promise, util.noop);
     });
 
+    try {
+      eval(`
+        it('should work on es classes', () => {
+          class MyESClass {
+            myMethod(str, callback) {
+              callback(str.toUpperCase());
+            }
+          }
+          util.promisifyAll(MyESClass);
+          assert(MyESClass.prototype.myMethod.promisified_);
+        });
+      `);
+    } catch (error) {
+      it.skip('should work on es classes');
+    }
+
     it('should optionally except an exclude list', () => {
       function FakeClass2() {}
 


### PR DESCRIPTION
Currently `promisifyAll` doesn't support es classes, where the methods are added in the class declaration:

```js
class MyClass {
  thisShouldBePromisified() {
    // but it currently isn't :(
  }
}
util.promisifyAll(MyClass);
// Uncaught TypeError: Cannot read property 'then' of undefined
new MyClass().thisShouldBePromisified().then(console.log)
```

Now here's where testing gets fun. The ts compiler will convert a class to whatever node version target, in this case v4, which means that we can't just create a class to test this on. In order to get around this we need to use `eval` to create a real es class that won't get transpiled.

Following this thought, you may think creating a `.js` file with the same code would suffice, **however**, since the tests also run on node v4, it would cause a syntax error and that's the reason eval is required. After that fact, there's no reason not to put that eval horror inside the `test/util.ts` method.

Once node v4 support is dropped this test should become much simpler