### PR TITLE
chore: upgrade and lock typescript at 2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "sinon": "^5.0.2",
     "source-map-support": "^0.5.4",
     "through2": "^2.0.3",
-    "typescript": "~2.8.1",
+    "typescript": "~2.9.1",
     "uuid": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "sinon": "^5.0.2",
     "source-map-support": "^0.5.4",
     "through2": "^2.0.3",
-    "typescript": "^2.8.1",
+    "typescript": "~2.8.1",
     "uuid": "^3.2.1"
   }
 }

--- a/src/logger-compat.ts
+++ b/src/logger-compat.ts
@@ -31,6 +31,7 @@ export interface CustomLevelsLoggerConfig extends LoggerConfig {
 
 // tslint:disable:no-any
 export type CustomLevelsLogger = {
+  [kFormat]: (...args: any[]) => string;
   [logLevel: string]: (...args: any[]) => CustomLevelsLogger;
 }&{
   format: (...args: any[]) => string;


### PR DESCRIPTION
TypeScript 2.9 just came out. This upgrades the TSC version and also locks it at 2.9.