### PR TITLE
chore: run CI as non-root user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
   node4:
     docker:
       - image: 'node:4'
+        user: node
     steps: &unit_tests_steps
       - checkout
       - run: &remove_package_lock
@@ -84,22 +85,27 @@ jobs:
   node6:
     docker:
       - image: 'node:6'
+        user: node
     steps: *unit_tests_steps
   node8:
     docker:
       - image: 'node:8'
+        user: node
     steps: *unit_tests_steps
   node9:
     docker:
       - image: 'node:9'
+        user: node
     steps: *unit_tests_steps
   node10:
     docker:
       - image: 'node:10'
+        user: node
     steps: *unit_tests_steps
   lint:
     docker:
       - image: 'node:8'
+        user: node
     steps:
       - checkout
       - run: *remove_package_lock
@@ -110,6 +116,7 @@ jobs:
   docs:
     docker:
       - image: 'node:8'
+        user: node
     steps:
       - checkout
       - run: *remove_package_lock
@@ -120,6 +127,7 @@ jobs:
   publish_npm:
     docker:
       - image: 'node:8'
+        user: node
     steps:
       - checkout
       - run:


### PR DESCRIPTION
`npm publish` did not work when run as root. Let's run as user `node` as we do in all other projects.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
