### PR TITLE
feat: expose Logger.LEVELS

### DIFF
--- a/src/logger-compat.ts
+++ b/src/logger-compat.ts
@@ -20,7 +20,7 @@
 
 import * as is from 'is';
 
-import {kFormat, LEVELS, Logger, LoggerConfig} from './logger';
+import {kFormat, Logger, LoggerConfig} from './logger';
 
 export interface CustomLevelsLoggerConfig extends LoggerConfig {
   /**
@@ -53,8 +53,8 @@ function createLogger(optionsOrLevel?: Partial<CustomLevelsLoggerConfig>|
       level: optionsOrLevel,
     };
   }
-  const options: CustomLevelsLoggerConfig =
-      Object.assign({levels: LEVELS}, Logger.DEFAULT_OPTIONS, optionsOrLevel);
+  const options: CustomLevelsLoggerConfig = Object.assign(
+      {levels: Logger.LEVELS}, Logger.DEFAULT_OPTIONS, optionsOrLevel);
   // ts: We construct other fields on result after its declaration.
   // tslint:disable-next-line:no-any
   const result: CustomLevelsLogger = new Logger(options) as any;
@@ -74,4 +74,4 @@ function createLogger(optionsOrLevel?: Partial<CustomLevelsLoggerConfig>|
  * Create a logger to print output to the console.
  * Omitted options will default to values provided in defaultLoggerOptions.
  */
-export const logger = Object.assign(createLogger, {LEVELS});
+export const logger = Object.assign(createLogger, {LEVELS: Logger.LEVELS});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -33,11 +33,6 @@ export interface LoggerConfig {
   tag: string;
 }
 
-/**
- * The default list of log levels.
- */
-export const LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
-
 export const kFormat = Symbol('Logger formatter');
 export const kTag = Symbol('Logger tag format');
 
@@ -49,6 +44,10 @@ export class Logger {
    * Default logger options.
    */
   static DEFAULT_OPTIONS: Readonly<LoggerConfig> = {level: 'error', tag: ''};
+  /**
+   * The default list of log levels.
+   */
+  static LEVELS = ['silent', 'error', 'warn', 'info', 'debug', 'silly'];
 
   private[kTag]: string;
 
@@ -73,7 +72,7 @@ export class Logger {
 
     // Get the list of levels.
     // This is undocumented behavior and subject to change.
-    const levels = (options as {levels?: string[]}).levels || LEVELS;
+    const levels = (options as {levels?: string[]}).levels || Logger.LEVELS;
 
     // Determine lowest log level.
     // If the given level is set to false, don't log anything.


### PR DESCRIPTION
This change just puts `LEVELS` as a static field on the `Logger` object.