### PR TITLE
fix: loosens metadata type to any in ServiceObject

### DIFF
--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -112,7 +112,8 @@ export interface StreamRequestOptions extends DecorateRequestOptions {
  * object requires specific behavior.
  */
 class ServiceObject extends EventEmitter {
-  metadata: {};
+  // tslint:disable-next-line:no-any
+  metadata: any;
   baseUrl?: string;
   protected parent: Service;
   private id?: string;


### PR DESCRIPTION
Fixes #176

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)