### PR TITLE
chore: release 0.20.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/common",
   "description": "Common components for Cloud APIs Node.js Client Libraries",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
[release notes](https://github.com/googleapis/nodejs-common/releases/edit/untagged-7a301c737c1937ecf0c4#)

----------

This is a patch release that contains several bug fixes, updated dependencies, and tool fixes. 

## Bug fixes
a7c763a fix: callback request with body and response (#182)
9146ec4 fix: ServiceObject: loosen metadata type (#181)
5921721 fix: UnhandledPromiseRejection in ServiceObject test (#175)

## Package updates
f59f537 fix(deps): update dependency retry-request to v4 (#179)
5b4132f chore(deps): update dependency sinon to v6 (#178)
272d3be chore(deps): update dependency gts to ^0.7.0 (#177)

## Keepin the lights on 
a36ee6a test: test the typescript install (#183)
f2de3e9 Configure Renovate (#170)
a35bd97 refactor: drop repo-tool as an exec wrapper (#173)
620844d fix: update linking for samples (#171)

