### PR TITLE
refactor: remove circular imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,12 @@ export {Operation} from './operation';
  * @type {module:common/service}
  * @private
  */
-export {Service, ServiceConfig, ServiceOptions} from './service';
+export {Service, ServiceConfig, ServiceOptions, StreamRequestOptions} from './service';
 /**
  * @type {module:common/serviceObject}
  * @private
  */
-export {CreateOptions, DeleteCallback, ExistsCallback, GetConfig, GetMetadataCallback, InstanceResponseCallback, Interceptor, Metadata, Methods, ServiceObject, ServiceObjectConfig, StreamRequestOptions} from './service-object';
+export {CreateOptions, DeleteCallback, ExistsCallback, GetConfig, GetMetadataCallback, InstanceResponseCallback, Interceptor, Metadata, Methods, ServiceObject, ServiceObjectConfig} from './service-object';
 /**
  * @type {module:common/util}
  * @private

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -25,7 +25,7 @@ import * as extend from 'extend';
 import * as is from 'is';
 import * as r from 'request';
 
-import {Service} from '.';
+import {Service, StreamRequestOptions} from '.';
 import {ApiError, BodyResponseCallback, DecorateRequestOptions, util} from './util';
 
 export interface Interceptor {
@@ -95,10 +95,6 @@ export interface GetConfig {
    * Create the object if it doesn't already exist.
    */
   autoCreate?: boolean;
-}
-
-export interface StreamRequestOptions extends DecorateRequestOptions {
-  shouldReturnStream: true;
 }
 
 /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -25,10 +25,14 @@ import * as is from 'is';
 import * as pify from 'pify';
 import * as r from 'request';
 
-import {StreamRequestOptions} from './service-object';
+
 import {BodyResponseCallback, DecorateRequestOptions, MakeAuthenticatedRequest, PackageJson, util} from './util';
 
 const PROJECT_ID_TOKEN = '{{projectId}}';
+
+export interface StreamRequestOptions extends DecorateRequestOptions {
+  shouldReturnStream: true;
+}
 
 export interface ServiceConfig {
   /**


### PR DESCRIPTION
This way `service` does not import `service-object`, only the
other way round.

