### PR TITLE
chore: remove dead code and packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "Tim Swast <swast@google.com>"
   ],
   "scripts": {
+    "generate-scaffolding": "repo-tools generate all",
     "docs": "jsdoc -c .jsdoc.js",
     "cover": "nyc --reporter=lcov mocha build/test && nyc report",
     "test-no-cover": "mocha build/test",
@@ -48,6 +49,7 @@
     "check": "gts check"
   },
   "dependencies": {
+    "@google-cloud/nodejs-repo-tools": "^2.3.0",
     "@google-cloud/projectify": "^0.3.0",
     "@google-cloud/promisify": "^0.3.0",
     "@types/duplexify": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "Tim Swast <swast@google.com>"
   ],
   "scripts": {
-    "publish-module": "node ../../scripts/publish.js common",
-    "generate-scaffolding": "repo-tools generate all",
     "docs": "jsdoc -c .jsdoc.js",
     "cover": "nyc --reporter=lcov mocha build/test && nyc report",
     "test-no-cover": "mocha build/test",
@@ -50,11 +48,11 @@
     "check": "gts check"
   },
   "dependencies": {
+    "@google-cloud/projectify": "^0.3.0",
     "@google-cloud/promisify": "^0.3.0",
     "@types/duplexify": "^3.5.0",
     "@types/request": "^2.47.0",
     "arrify": "^1.0.1",
-    "axios": "^0.18.0",
     "duplexify": "^3.6.0",
     "ent": "^2.2.0",
     "extend": "^3.0.1",
@@ -63,11 +61,9 @@
     "pify": "^4.0.0",
     "request": "^2.87.0",
     "retry-request": "^4.0.0",
-    "stream-events": "^1.0.4",
     "through2": "^2.0.3"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^2.3.0",
     "@types/arrify": "^1.0.4",
     "@types/ent": "^2.2.1",
     "@types/extend": "^3.0.0",
@@ -79,11 +75,11 @@
     "@types/node": "^10.3.1",
     "@types/pify": "^3.0.2",
     "@types/proxyquire": "^1.3.28",
-    "@types/shimmer": "^1.0.1",
     "@types/sinon": "^5.0.1",
     "@types/through2": "^2.0.33",
     "@types/tmp": "0.0.33",
     "@types/uuid": "^3.4.3",
+    "axios": "^0.18.0",
     "codecov": "^3.0.2",
     "gts": "^0.8.0",
     "ink-docstrap": "^1.3.2",
@@ -97,7 +93,6 @@
     "nyc": "^12.0.2",
     "power-assert": "^1.5.0",
     "proxyquire": "^2.0.1",
-    "shimmer": "^1.2.0",
     "sinon": "^6.0.0",
     "source-map-support": "^0.5.6",
     "tmp": "0.0.33",

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,6 @@ import {CredentialBody} from 'google-auth-library/build/src/auth/credentials';
 import * as is from 'is';
 import * as r from 'request';
 import * as retryRequest from 'retry-request';
-import {TransformOptions} from 'stream';
 import * as through from 'through2';
 
 import {Interceptor} from './service-object';
@@ -72,29 +71,6 @@ export type AbortableDuplex = duplexify.Duplexify&Abortable;
 export interface PackageJson {
   name: string;
   version: string;
-}
-
-export interface CreateLimiterOptions {
-  /**
-   * The maximum number of API calls to make.
-   */
-  maxApiCalls?: number;
-
-  /**
-   * Options to pass to the Stream constructor.
-   */
-  streamOptions?: TransformOptions;
-}
-
-export interface GlobalContext {
-  config_: {};
-}
-
-export interface GlobalConfig {
-  projectId?: string;
-  credentials?: {};
-  keyFilename?: string;
-  interceptors_?: {};
 }
 
 export interface MakeAuthenticatedRequestFactoryConfig extends
@@ -175,7 +151,6 @@ export interface DecorateRequestOptions extends r.OptionsWithUri {
   interceptors_?: Interceptor[];
   shouldReturnStream?: boolean;
 }
-
 
 export interface ParsedHttpResponseBody {
   body: ResponseBody;
@@ -479,7 +454,6 @@ export class Util {
 
     return false;
   }
-
 
   /**
    * Get a function for making authenticated requests.

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,6 +18,7 @@
  * @module common/util
  */
 
+import {replaceProjectIdToken} from '@google-cloud/projectify';
 import * as duplexify from 'duplexify';
 import * as ent from 'ent';
 import * as extend from 'extend';
@@ -26,8 +27,7 @@ import {CredentialBody} from 'google-auth-library/build/src/auth/credentials';
 import * as is from 'is';
 import * as r from 'request';
 import * as retryRequest from 'retry-request';
-import {Transform, TransformOptions} from 'stream';
-import * as streamEvents from 'stream-events';
+import {TransformOptions} from 'stream';
 import * as through from 'through2';
 
 import {Interceptor} from './service-object';
@@ -714,150 +714,18 @@ export class Util {
     if (is.object(reqOpts.qs)) {
       delete reqOpts.qs.autoPaginate;
       delete reqOpts.qs.autoPaginateVal;
-      reqOpts.qs = util.replaceProjectIdToken(reqOpts.qs, projectId);
+      reqOpts.qs = replaceProjectIdToken(reqOpts.qs, projectId);
     }
 
     if (is.object(reqOpts.json)) {
       delete reqOpts.json.autoPaginate;
       delete reqOpts.json.autoPaginateVal;
-      reqOpts.json = util.replaceProjectIdToken(reqOpts.json, projectId);
+      reqOpts.json = replaceProjectIdToken(reqOpts.json, projectId);
     }
 
-    reqOpts.uri = util.replaceProjectIdToken(reqOpts.uri, projectId);
+    reqOpts.uri = replaceProjectIdToken(reqOpts.uri, projectId);
 
     return reqOpts;
-  }
-
-  /**
-   * Populate the `{{projectId}}` placeholder.
-   *
-   * @throws {Error} If a projectId is required, but one is not provided.
-   *
-   * @param {*} - Any input value that may contain a placeholder. Arrays and objects will be looped.
-   * @param {string} projectId - A projectId. If not provided
-   * @return {*} - The original argument with all placeholders populated.
-   */
-  // tslint:disable-next-line:no-any
-  replaceProjectIdToken(value: string|string[]|{}, projectId: string): any {
-    if (is.array(value)) {
-      value = (value as string[])
-                  .map(v => util.replaceProjectIdToken(v, projectId));
-    }
-
-    if (value !== null && typeof value === 'object' &&
-        is.fn(value.hasOwnProperty)) {
-      for (const opt in value) {
-        if (value.hasOwnProperty(opt)) {
-          // tslint:disable-next-line:no-any
-          const v = value as any;
-          v[opt] = util.replaceProjectIdToken(v[opt], projectId);
-        }
-      }
-    }
-
-    if (typeof value === 'string' &&
-        (value as string).indexOf('{{projectId}}') > -1) {
-      if (!projectId || projectId === '{{projectId}}') {
-        throw new MissingProjectIdError();
-      }
-      value = (value as string).replace(/{{projectId}}/g, projectId);
-    }
-
-    return value;
-  }
-
-  /**
-   * Extend a global configuration object with user options provided at the time
-   * of sub-module instantiation.
-   *
-   * Connection details currently come in two ways: `credentials` or
-   * `keyFilename`. Because of this, we have a special exception when overriding
-   * a global configuration object. If a user provides either to the global
-   * configuration, then provides another at submodule instantiation-time, the
-   * latter is preferred.
-   *
-   * @param  {object} globalConfig - The global configuration object.
-   * @param  {object=} overrides - The instantiation-time configuration object.
-   * @return {object}
-   */
-  extendGlobalConfig(globalConfig: GlobalConfig|null, overrides: GlobalConfig) {
-    globalConfig = globalConfig || {};
-    overrides = overrides || {};
-
-    const defaultConfig: GlobalConfig = {};
-
-    if (process.env.GCLOUD_PROJECT) {
-      defaultConfig.projectId = process.env.GCLOUD_PROJECT;
-    }
-
-    const options = extend({}, globalConfig);
-
-    const hasGlobalConnection = options.credentials || options.keyFilename;
-    const isOverridingConnection =
-        overrides.credentials || overrides.keyFilename;
-
-    if (hasGlobalConnection && isOverridingConnection) {
-      delete options.credentials;
-      delete options.keyFilename;
-    }
-
-    const extendedConfig = extend(true, defaultConfig, options, overrides);
-
-    // Preserve the original (not cloned) interceptors.
-    extendedConfig.interceptors_ = globalConfig.interceptors_;
-
-    return extendedConfig;
-  }
-
-  /**
-   * Merge and validate API configurations.
-   *
-   * @param {object} globalContext - gcloud-level context.
-   * @param {object} globalContext.config_ - gcloud-level configuration.
-   * @param {object} localConfig - Service-level configurations.
-   * @return {object} config - Merged and validated configuration.
-   */
-  normalizeArguments(
-      globalContext: GlobalContext|null, localConfig: GlobalConfig) {
-    const globalConfig = globalContext && globalContext.config_ as GlobalConfig;
-    return util.extendGlobalConfig(globalConfig, localConfig);
-  }
-
-  /**
-   * Limit requests according to a `maxApiCalls` limit.
-   *
-   * @param {function} makeRequestFn - The function that will be called.
-   * @param {object=} options - Configuration object.
-   * @param {number} options.maxApiCalls - The maximum number of API calls to make.
-   * @param {object} options.streamOptions - Options to pass to the Stream constructor.
-   */
-  createLimiter(makeRequestFn: Function, options?: CreateLimiterOptions) {
-    options = options || {};
-
-    const streamOptions = options.streamOptions || {};
-    streamOptions.objectMode = true;
-    const stream = streamEvents(new Transform(streamOptions)) as Transform;
-
-    let requestsMade = 0;
-    let requestsToMake = -1;
-
-    if (is.number(options.maxApiCalls)) {
-      requestsToMake = options.maxApiCalls!;
-    }
-
-    return {
-      // tslint:disable-next-line:no-any
-      makeRequest(...args: any[]) {
-        requestsMade++;
-        if (requestsToMake >= 0 && requestsMade > requestsToMake) {
-          stream.push(null);
-          return;
-        }
-        makeRequestFn.apply(null, args);
-        return stream;
-      },
-      stream,
-    };
   }
 
   // tslint:disable-next-line:no-any
@@ -902,17 +770,6 @@ export class Util {
             .replace('/', '-');  // For UA spec-compliance purposes.
 
     return hyphenatedPackageName + '/' + packageJson.version;
-  }
-
-  /**
-   * This will mask properties of an object from console.log.
-   *
-   * @param {object} object - The object to assign the property to.
-   * @param {string} propName - Property name.
-   * @param {*} value - Value.
-   */
-  privatize(object: {}, propName: string, value: {}) {
-    Object.defineProperty(object, propName, {value, writable: true});
   }
 }
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
+import {replaceProjectIdToken} from '@google-cloud/projectify';
 import * as assert from 'assert';
 import {AxiosRequestConfig} from 'axios';
 import * as duplexify from 'duplexify';
 import * as extend from 'extend';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
-import * as is from 'is';
 import * as nock from 'nock';
 import * as proxyquire from 'proxyquire';
 import * as request from 'request';
 import * as retryRequest from 'retry-request';
 import * as sinon from 'sinon';
 import * as stream from 'stream';
-import * as streamEvents from 'stream-events';
 
-import {Abortable, ApiError, DecorateRequestOptions, GlobalConfig, MakeAuthenticatedRequestFactoryConfig, MakeRequestConfig, Util} from '../src/util';
+import {Abortable, ApiError, DecorateRequestOptions, MakeAuthenticatedRequestFactoryConfig, MakeRequestConfig, Util} from '../src/util';
 
 nock.disableNetConnect();
 
@@ -72,9 +71,10 @@ function fakeRetryRequest() {
 }
 
 // tslint:disable-next-line:no-any
-let streamEventsOverride: any;
-function fakeStreamEvents() {
-  return (streamEventsOverride || streamEvents).apply(null, arguments);
+let replaceProjectIdTokenOverride: any;
+function fakeReplaceProjectIdToken() {
+  return (replaceProjectIdTokenOverride || replaceProjectIdToken)
+      .apply(null, arguments);
 }
 
 describe('common/util', () => {
@@ -99,7 +99,9 @@ describe('common/util', () => {
              'google-auth-library': fakeGoogleAuth,
              request: fakeRequest,
              'retry-request': fakeRetryRequest,
-             'stream-events': fakeStreamEvents,
+             '@google-cloud/projectify': {
+               replaceProjectIdToken: fakeReplaceProjectIdToken,
+             },
            }).util;
     const utilCached = extend(true, {}, util);
 
@@ -121,7 +123,7 @@ describe('common/util', () => {
     sandbox = sinon.createSandbox();
     requestOverride = null;
     retryRequestOverride = null;
-    streamEventsOverride = null;
+    replaceProjectIdTokenOverride = null;
     utilOverrides = {};
   });
   afterEach(() => {
@@ -313,53 +315,6 @@ describe('common/util', () => {
       const partialFailureError = new util.PartialFailureError(error);
 
       assert.strictEqual(partialFailureError.message, expectedErrorMessage);
-    });
-  });
-
-  describe('extendGlobalConfig', () => {
-    it('should favor `keyFilename` when `credentials` is global', () => {
-      const globalConfig = {credentials: {}};
-      const options = util.extendGlobalConfig(globalConfig, {
-        keyFilename: 'key.json',
-      });
-      assert.strictEqual(options.credentials, undefined);
-    });
-
-    it('should favor `credentials` when `keyFilename` is global', () => {
-      const globalConfig = {keyFilename: 'key.json'};
-      const options = util.extendGlobalConfig(globalConfig, {credentials: {}});
-      assert.strictEqual(options.keyFilename, undefined);
-    });
-
-    it('should honor the GCLOUD_PROJECT environment variable', () => {
-      const newProjectId = 'envvar-project-id';
-      const cachedProjectId = process.env.GCLOUD_PROJECT;
-      process.env.GCLOUD_PROJECT = newProjectId;
-
-      // No projectId specified:
-      const globalConfig = {keyFilename: 'key.json'};
-      const options = util.extendGlobalConfig(globalConfig, {});
-
-      if (cachedProjectId) {
-        process.env.GCLOUD_PROJECT = cachedProjectId;
-      } else {
-        delete process.env.GCLOUD_PROJECT;
-      }
-
-      assert.strictEqual(options.projectId, newProjectId);
-    });
-
-    it('should not modify original object', () => {
-      const globalConfig = {keyFilename: 'key.json'};
-      util.extendGlobalConfig(globalConfig, {credentials: {}});
-      assert.deepStrictEqual(globalConfig, {keyFilename: 'key.json'});
-    });
-
-    it('should link the original interceptors_', () => {
-      const interceptors: Array<{}> = [];
-      const globalConfig = {interceptors_: interceptors};
-      util.extendGlobalConfig(globalConfig, {});
-      assert.strictEqual(globalConfig.interceptors_, interceptors);
     });
   });
 
@@ -1468,11 +1423,11 @@ describe('common/util', () => {
       };
       const decoratedUri = 'http://decorated';
 
-      stub('replaceProjectIdToken', (uri, projectId_) => {
+      replaceProjectIdTokenOverride = (uri: string, projectId_: string) => {
         assert.strictEqual(uri, reqOpts.uri);
         assert.strictEqual(projectId_, projectId);
         return decoratedUri;
-      });
+      };
 
       assert.deepStrictEqual(util.decorateRequest(reqOpts, projectId), {
         uri: decoratedUri,
@@ -1485,7 +1440,7 @@ describe('common/util', () => {
 
     it('should replace any {{projectId}} it finds', () => {
       assert.deepStrictEqual(
-          util.replaceProjectIdToken(
+          replaceProjectIdToken(
               {
                 here: 'A {{projectId}} Z',
                 nested: {
@@ -1541,7 +1496,7 @@ describe('common/util', () => {
 
     it('should replace more than one {{projectId}}', () => {
       assert.deepStrictEqual(
-          util.replaceProjectIdToken(
+          replaceProjectIdToken(
               {
                 here: 'A {{projectId}} M {{projectId}} Z',
               },
@@ -1558,106 +1513,6 @@ describe('common/util', () => {
           here: '{{projectId}}',
         });
       }, new RegExp(util.MissingProjectIdError.name));
-    });
-  });
-
-  describe('normalizeArguments', () => {
-    const fakeContext = {
-      config_: {
-        projectId: 'grapespaceship911',
-      },
-    };
-
-    it('should return an extended object', () => {
-      const local = {a: 'b'} as GlobalConfig;
-      let config;
-
-      stub('extendGlobalConfig', (globalConfig, localConfig) => {
-        assert.strictEqual(globalConfig, fakeContext.config_);
-        assert.strictEqual(localConfig, local);
-        return fakeContext.config_;
-      });
-
-      config = util.normalizeArguments(fakeContext, local);
-      assert.strictEqual(config, fakeContext.config_);
-    });
-  });
-
-  describe('createLimiter', () => {
-    function REQUEST_FN() {}
-    const OPTIONS = {
-      streamOptions: {
-        highWaterMark: 8,
-      },
-    };
-
-    it('should create an object stream with stream-events', (done) => {
-      streamEventsOverride = (stream: stream.Readable) => {
-        // tslint:disable-next-line:no-any
-        assert.strictEqual((stream as any)._readableState.objectMode, true);
-        setImmediate(done);
-        return stream;
-      };
-
-      util.createLimiter(REQUEST_FN, OPTIONS);
-    });
-
-    it('should return a makeRequest function', () => {
-      const limiter = util.createLimiter(REQUEST_FN, OPTIONS);
-      assert(is.fn(limiter.makeRequest));
-    });
-
-    it('should return the created stream', () => {
-      const streamEventsStream = {};
-
-      streamEventsOverride = () => {
-        return streamEventsStream;
-      };
-
-      const limiter = util.createLimiter(REQUEST_FN, OPTIONS);
-      assert.strictEqual(limiter.stream, streamEventsStream);
-    });
-
-    it('should pass stream options to through', () => {
-      const limiter = util.createLimiter(REQUEST_FN, OPTIONS);
-
-      assert.strictEqual(
-          // tslint:disable-next-line:no-any
-          (limiter.stream as any)._readableState.highWaterMark,
-          OPTIONS.streamOptions.highWaterMark);
-    });
-
-    describe('makeRequest', () => {
-      it('should pass arguments to request method', (done) => {
-        const args = [{}, {}];
-
-        const limiter = util.createLimiter((obj1: {}, obj2: {}) => {
-          assert.strictEqual(obj1, args[0]);
-          assert.strictEqual(obj2, args[1]);
-          done();
-        });
-
-        limiter.makeRequest.apply(null, args);
-      });
-
-      it('should not make more requests than the limit', (done) => {
-        let callsMade = 0;
-        const maxApiCalls = 10;
-
-        const limiter = util.createLimiter(() => {
-          callsMade++;
-          limiter.makeRequest();
-        }, {
-          maxApiCalls,
-        });
-
-        limiter.makeRequest();
-
-        limiter.stream.on('data', util.noop).on('end', () => {
-          assert.strictEqual(callsMade, maxApiCalls);
-          done();
-        });
-      });
     });
   });
 
@@ -1716,23 +1571,6 @@ describe('common/util', () => {
       });
 
       assert.strictEqual(userAgent, 'gcloud-node-storage/0.1.0');
-    });
-  });
-
-  describe('privatize', () => {
-    it('should set value', () => {
-      // tslint:disable-next-line:no-any
-      const obj: any = {};
-      util.privatize(obj, 'value', true);
-      assert.strictEqual(obj.value, true);
-    });
-
-    it('should allow values to be overwritten', () => {
-      // tslint:disable-next-line:no-any
-      const obj: any = {};
-      util.privatize(obj, 'value', true);
-      obj.value = false;
-      assert.strictEqual(obj.value, false);
     });
   });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -723,7 +723,7 @@ describe('common/util', () => {
       it('should decorate the request', (done) => {
         const decoratedRequest = {};
         sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
-        stub('decorateRequest', (reqOpts_, projectId) => {
+        stub('decorateRequest', (reqOpts_) => {
           assert.strictEqual(reqOpts_, fakeReqOpts);
           return decoratedRequest;
         });


### PR DESCRIPTION
BREAKING CHANGE: This change removes the following methods from the `util` class:
- `util.replaceProjectIdToken`
- `util.extendGlobalConfig`
- `util.normalizeArguments`
- `util.createLimiter`
- `util.privatize`

These methods have either been replaced with smaller single purpose modules, or are no longer necessary. 

Side note: deleting code is fun, and feels really good.