### PR TITLE
feat: make HTTP dependency configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "google-auth-library": "^1.6.0",
     "is": "^3.2.1",
     "pify": "^4.0.0",
-    "request": "^2.87.0",
     "retry-request": "^4.0.0",
     "through2": "^2.0.3"
   },
@@ -95,6 +94,7 @@
     "nyc": "^12.0.2",
     "power-assert": "^1.5.0",
     "proxyquire": "^2.0.1",
+    "request": "^2.88.0",
     "sinon": "^6.0.0",
     "source-map-support": "^0.5.6",
     "tmp": "0.0.33",

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -23,7 +23,7 @@ import * as arrify from 'arrify';
 import {EventEmitter} from 'events';
 import * as extend from 'extend';
 import * as is from 'is';
-import * as r from 'request';
+import * as r from 'request';  // Only needed for type declarations.
 
 import {Service, StreamRequestOptions} from '.';
 import {ApiError, BodyResponseCallback, DecorateRequestOptions, util} from './util';
@@ -73,6 +73,11 @@ export interface ServiceObjectConfig {
    * object is Bucket.
    */
   parent: Service|ServiceObject;
+
+  /**
+   * Dependency for HTTP calls.
+   */
+  requestModule: typeof r;
 }
 
 export interface Methods {
@@ -121,6 +126,7 @@ class ServiceObject extends EventEmitter {
   Promise?: PromiseConstructor;
   // tslint:disable-next-line:no-any
   [index: string]: any;
+  requestModule: typeof r;
 
   /*
    * @constructor
@@ -150,6 +156,7 @@ class ServiceObject extends EventEmitter {
     this.methods = config.methods || {};
     this.interceptors = [];
     this.Promise = this.parent ? this.parent.Promise : undefined;
+    this.requestModule = config.requestModule;
 
     if (config.methods) {
       Object.getOwnPropertyNames(ServiceObject.prototype)

--- a/src/service.ts
+++ b/src/service.ts
@@ -23,7 +23,7 @@ import * as extend from 'extend';
 import {GoogleAuth} from 'google-auth-library';
 import * as is from 'is';
 import * as pify from 'pify';
-import * as r from 'request';
+import * as r from 'request';  // Only needed for type declarations.
 
 
 import {BodyResponseCallback, DecorateRequestOptions, MakeAuthenticatedRequest, PackageJson, util} from './util';
@@ -47,6 +47,7 @@ export interface ServiceConfig {
 
   projectIdRequired?: boolean;
   packageJson: PackageJson;
+  requestModule: typeof r;
 }
 
 export interface ServiceOptions {
@@ -71,6 +72,7 @@ export class Service {
   makeAuthenticatedRequest: MakeAuthenticatedRequest;
   authClient: GoogleAuth;
   private getCredentials: {};
+  requestModule: typeof r;
 
   /**
    * Service is a base class, meant to be inherited from by a "service," like
@@ -97,6 +99,7 @@ export class Service {
     this.projectId = options.projectId || PROJECT_ID_TOKEN;
     this.projectIdRequired = config.projectIdRequired !== false;
     this.Promise = options.promise || Promise;
+    this.requestModule = config.requestModule;
 
     const reqCfg = extend({}, config, {
       projectIdRequired: this.projectIdRequired,
@@ -105,6 +108,7 @@ export class Service {
       keyFile: options.keyFilename,
       email: options.email,
       token: options.token,
+      request: this.requestModule,
     });
 
     this.makeAuthenticatedRequest =

--- a/test/fixtures/kitchen/src/index.ts
+++ b/test/fixtures/kitchen/src/index.ts
@@ -4,7 +4,7 @@ import {GoogleAuthOptions, Operation,Service, ServiceConfig, ServiceOptions,
   ServiceObjectConfig, StreamRequestOptions, Abortable, AbortableDuplex,
   ApiError, util} from '@google-cloud/common';
 
-util.makeRequest({url: 'test'}, (err, body, res) => {
+util.makeRequest({url: 'test'}, {}, (err, body, res) => {
   console.log(err);
 });
 

--- a/test/operation.ts
+++ b/test/operation.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from 'assert';
+import * as r from 'request';  // Only needed for type declarations.
 import * as sinon from 'sinon';
 
 import {Service} from '../src';
@@ -32,7 +33,11 @@ describe('Operation', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    operation = new Operation({parent: FAKE_SERVICE, id: OPERATION_ID});
+    operation = new Operation({
+      parent: FAKE_SERVICE,
+      id: OPERATION_ID,
+      requestModule: {} as typeof r,
+    });
     operation.Promise = Promise;
   });
 

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -41,6 +41,7 @@ describe('ServiceObject', () => {
     parent: {} as Service,
     id: 'id',
     createMethod: util.noop,
+    requestModule: {} as typeof r,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
`Service`, `ServiceObject`, and `util.makeRequest()` must be
initialized with an HTTP dependency, e.g., `request`.

The second parameter of `util.makeRequest`, a configuration
object, is mandatory.

Ultimately, this change will improve startup time for the
client libraries. Before this change, `nodejs-common` required
`request` as HTTP dependency, which is a very large dependency. By making the
HTTP dependency configurable, client libraries can use
smaller dependencies instead of `request`. Thus reducing startup time.

For an end-to-end integration, see https://github.com/googleapis/nodejs-translate/pull/98.