### PR TITLE
Enhance typing of ServiceObject.prototype.get

### DIFF
--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -106,8 +106,7 @@ export interface ResponseCallback {
 
 export type SetMetadataResponse = [r.Request];
 
-export type GetResponse =
-    [ServiceObject | null | undefined, r.Response | undefined];
+export type GetResponse = [ServiceObject, r.Response];
 
 /**
  * ServiceObject is a base class, meant to be inherited from by a "service

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -106,6 +106,9 @@ export interface ResponseCallback {
 
 export type SetMetadataResponse = [r.Request];
 
+export type GetResponse =
+    [ServiceObject | null | undefined, r.Response | undefined];
+
 /**
  * ServiceObject is a base class, meant to be inherited from by a "service
  * object," like a BigQuery dataset or Storage bucket.
@@ -276,10 +279,12 @@ class ServiceObject extends EventEmitter {
    * @param {object} callback.instance - The instance.
    * @param {object} callback.apiResponse - The full API response.
    */
-  get(config: GetConfig, callback?: InstanceResponseCallback): void;
+  get(): Promise<GetResponse>;
   get(callback: InstanceResponseCallback): void;
-  get(configOrCallback: GetConfig|InstanceResponseCallback,
-      callback?: InstanceResponseCallback): void {
+  get(config: GetConfig): Promise<GetResponse>;
+  get(config: GetConfig, callback: InstanceResponseCallback): void;
+  get(configOrCallback?: GetConfig|InstanceResponseCallback,
+      callback?: InstanceResponseCallback): void|Promise<GetResponse> {
     const self = this;
 
     let config: GetConfig = {};
@@ -298,7 +303,7 @@ class ServiceObject extends EventEmitter {
         err: ApiError|null, instance: ServiceObject, apiResponse: r.Response) {
       if (err) {
         if (err.code === 409) {
-          self.get(config, callback);
+          self.get(config, callback!);
           return;
         }
         callback!(err, null, apiResponse);

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -278,9 +278,8 @@ class ServiceObject extends EventEmitter {
    * @param {object} callback.instance - The instance.
    * @param {object} callback.apiResponse - The full API response.
    */
-  get(): Promise<GetResponse>;
+  get(config?: GetConfig): Promise<GetResponse>;
   get(callback: InstanceResponseCallback): void;
-  get(config: GetConfig): Promise<GetResponse>;
   get(config: GetConfig, callback: InstanceResponseCallback): void;
   get(configOrCallback?: GetConfig|InstanceResponseCallback,
       callback?: InstanceResponseCallback): void|Promise<GetResponse> {

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -313,7 +313,8 @@ describe('ServiceObject', () => {
 
   describe('exists', () => {
     it('should call get', (done) => {
-      serviceObject.get = () => {
+      // tslint:disable-next-line:no-any
+      (serviceObject as any).get = () => {
         done();
       };
 
@@ -323,14 +324,10 @@ describe('ServiceObject', () => {
     it('should execute callback with false if 404', (done) => {
       const error = new ApiError('');
       error.code = 404;
-      serviceObject.get =
-          (configOrCallback: SO.GetConfig|SO.InstanceResponseCallback,
-           callback?: SO.InstanceResponseCallback) => {
-            callback = typeof configOrCallback === 'function' ?
-                configOrCallback :
-                callback;
-            callback!(error);
-          };
+      // tslint:disable-next-line:no-any
+      (serviceObject as any).get = (callback: SO.InstanceResponseCallback) => {
+        callback(error);
+      };
 
       serviceObject.exists((err, exists) => {
         assert.ifError(err);
@@ -342,15 +339,10 @@ describe('ServiceObject', () => {
     it('should execute callback with error if not 404', (done) => {
       const error = new ApiError('');
       error.code = 500;
-
-      serviceObject.get =
-          (configOrCallback: SO.GetConfig|SO.InstanceResponseCallback,
-           callback?: SO.InstanceResponseCallback) => {
-            callback = typeof configOrCallback === 'function' ?
-                configOrCallback :
-                callback;
-            callback!(error);
-          };
+      // tslint:disable-next-line:no-any
+      (serviceObject as any).get = (callback: SO.InstanceResponseCallback) => {
+        callback(error);
+      };
 
       serviceObject.exists((err, exists) => {
         assert.strictEqual(err, error);
@@ -360,14 +352,10 @@ describe('ServiceObject', () => {
     });
 
     it('should execute callback with true if no error', (done) => {
-      serviceObject.get =
-          (configOrCallback: SO.GetConfig|SO.InstanceResponseCallback,
-           callback?: SO.InstanceResponseCallback) => {
-            callback = typeof configOrCallback === 'function' ?
-                configOrCallback :
-                callback;
-            callback!(null);
-          };
+      // tslint:disable-next-line:no-any
+      (serviceObject as any).get = (callback: SO.InstanceResponseCallback) => {
+        callback(null);
+      };
 
       serviceObject.exists((err, exists) => {
         assert.ifError(err);
@@ -489,7 +477,8 @@ describe('ServiceObject', () => {
                 callback = typeof optionsOrCallback === 'function' ?
                     optionsOrCallback :
                     callback;
-                serviceObject.get =
+                // tslint:disable-next-line:no-any
+                (serviceObject as any).get =
                     (configOrCallback: SO.GetConfig|SO.InstanceResponseCallback,
                      callback?: SO.InstanceResponseCallback) => {
                       const config = configOrCallback as SO.GetConfig;
@@ -511,7 +500,8 @@ describe('ServiceObject', () => {
           const error = new ApiError('errrr');
           error.code = 409;
           serviceObject.create = (callback: SO.InstanceResponseCallback) => {
-            serviceObject.get =
+            // tslint:disable-next-line:no-any
+            (serviceObject as any).get =
                 (configOrCallback: SO.GetConfig|SO.InstanceResponseCallback,
                  callback?: SO.InstanceResponseCallback) => {
                   const config = typeof configOrCallback === 'object' ?


### PR DESCRIPTION
Previously the type declarations for ServiceObject.prototype.get did not include signatures for the "promisified" version of the method. This PR adds suitable Promise-returning signatures. This also simplifies (`any`s) some of the `serviceObject.get` types in the unit tests, which are primarily designed to test run-time behavior rather than type design. 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
