### PR TITLE
fix(service): use getProjectId instead of getDefaultProjectId

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -142,7 +142,7 @@ export class Service {
   }
 
   protected async getProjectIdAsync(): Promise<string> {
-    const projectId = await this.authClient.getDefaultProjectId();
+    const projectId = await this.authClient.getProjectId();
     if (this.projectId === PROJECT_ID_TOKEN && projectId) {
       this.projectId = projectId;
     }

--- a/test/service.ts
+++ b/test/service.ts
@@ -197,7 +197,7 @@ describe('Service', () => {
   describe('getProjectId', () => {
     it('should get the project ID from the auth client', (done) => {
       service.authClient = {
-        getDefaultProjectId() {
+        getProjectId() {
           done();
         },
       };
@@ -209,7 +209,7 @@ describe('Service', () => {
       const error = new Error('Error.');
 
       service.authClient = {
-        async getDefaultProjectId() {
+        async getProjectId() {
           throw error;
         },
       };
@@ -225,7 +225,7 @@ describe('Service', () => {
       const projectId = 'detected-project-id';
 
       service.authClient = {
-        async getDefaultProjectId() {
+        async getProjectId() {
           return projectId;
         },
       };


### PR DESCRIPTION
Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)