### PR TITLE
chore: Remove support for custom PromiseConstructor

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -79,12 +79,11 @@ export class Operation extends ServiceObject {
    * @return {promise}
    */
   promise() {
-    return new this.Promise!
-        ((resolve: Function, reject: (err: Error) => void) => {
-          this.on('error', reject).on('complete', (metadata: {}) => {
-            resolve([metadata]);
-          });
-        });
+    return new Promise((resolve: Function, reject: (err: Error) => void) => {
+      this.on('error', reject).on('complete', (metadata: {}) => {
+        resolve([metadata]);
+      });
+    });
   }
 
   /**

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -29,8 +29,6 @@ import {StreamRequestOptions} from '.';
 import {ApiError, BodyResponseCallback, DecorateRequestOptions, util} from './util';
 
 export interface ServiceObjectParent {
-  // tslint:disable-next-line:variable-name
-  Promise?: PromiseConstructor;
   requestStream(reqOpts: DecorateRequestOptions): r.Request;
   request(reqOpts: DecorateRequestOptions): Promise<r.Response>;
   request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
@@ -136,8 +134,6 @@ class ServiceObject extends EventEmitter {
   private createMethod?: Function;
   protected methods: Methods;
   protected interceptors: Interceptor[];
-  // tslint:disable-next-line:variable-name
-  Promise?: PromiseConstructor;
   // tslint:disable-next-line:no-any
   [index: string]: any;
   requestModule: typeof r;
@@ -169,7 +165,6 @@ class ServiceObject extends EventEmitter {
     this.createMethod = config.createMethod;
     this.methods = config.methods || {};
     this.interceptors = [];
-    this.Promise = this.parent ? this.parent.Promise : undefined;
     this.requestModule = config.requestModule;
 
     if (config.methods) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -51,7 +51,6 @@ export interface ServiceConfig {
 export interface ServiceOptions {
   interceptors_?: {};
   projectId?: string;
-  promise?: PromiseConstructor;
   credentials?: {};
   keyFilename?: string;
   email?: string;
@@ -65,8 +64,6 @@ export class Service {
   private packageJson: PackageJson;
   projectId: string;
   private projectIdRequired: boolean;
-  // tslint:disable-next-line:variable-name
-  Promise: PromiseConstructor;
   makeAuthenticatedRequest: MakeAuthenticatedRequest;
   authClient: GoogleAuth;
   private getCredentials: {};
@@ -96,7 +93,6 @@ export class Service {
     this.packageJson = config.packageJson;
     this.projectId = options.projectId || PROJECT_ID_TOKEN;
     this.projectIdRequired = config.projectIdRequired !== false;
-    this.Promise = options.promise || Promise;
     this.requestModule = config.requestModule;
 
     const reqCfg = extend({}, config, {

--- a/test/operation.ts
+++ b/test/operation.ts
@@ -94,13 +94,6 @@ describe('Operation', () => {
       operation.startPolling_ = util.noop;
     });
 
-    it('should return an instance of the localized Promise', () => {
-      // tslint:disable-next-line:variable-name
-      const FakePromise = (operation.Promise = () => {});
-      const promise = operation.promise();
-      assert(promise instanceof FakePromise);
-    });
-
     it('should reject the promise if an error occurs', () => {
       const error = new Error('err');
 

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -114,18 +114,6 @@ describe('ServiceObject', () => {
       assert.strictEqual(typeof serviceObject.create, 'function');
       assert.strictEqual(serviceObject.delete, undefined);
     });
-
-    it('should localize the Promise object', () => {
-      // tslint:disable-next-line:variable-name
-      const FakePromise = () => {};
-      const config = extend({}, CONFIG, {
-        parent: {
-          Promise: FakePromise,
-        },
-      });
-      const serviceObject = new ServiceObject(config) as FakeServiceObject;
-      assert.strictEqual(serviceObject.Promise, FakePromise);
-    });
   });
 
   describe('create', () => {

--- a/test/service.ts
+++ b/test/service.ts
@@ -171,17 +171,6 @@ describe('Service', () => {
       assert.strictEqual(service.projectIdRequired, true);
     });
 
-    it('should localize the Promise object', () => {
-      // tslint:disable-next-line:variable-name
-      const FakePromise = () => {};
-      const service = new Service(fakeCfg, {promise: FakePromise});
-      assert.strictEqual(service.Promise, FakePromise);
-    });
-
-    it('should localize the native Promise object by default', () => {
-      assert.strictEqual(service.Promise, global.Promise);
-    });
-
     it('should disable forever agent for Cloud Function envs', () => {
       process.env.FUNCTION_NAME = 'cloud-function-name';
       const service = new Service(CONFIG, OPTIONS);


### PR DESCRIPTION
BREAKING CHANGE: This removes support for custom localized `Promise` in `Service`, `ServiceObject`, and `Operation` in favor of consistently using `global.Promise`. Closes #107.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [?] Appropriate docs were updated (if necessary)

Regarding docs, I didn't see any in this repo specifically that needed updating. That doesn't mean they're not there!