### PR TITLE
fix: Do not retry streaming POST requests.

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -153,6 +153,7 @@ export interface DecorateRequestOptions extends r.OptionsWithUri {
   autoPaginate?: boolean;
   autoPaginateVal?: boolean;
   objectMode?: boolean;
+  maxRetries?: number;
   uri: string;
   interceptors_?: Interceptor[];
   shouldReturnStream?: boolean;
@@ -382,6 +383,7 @@ export class Util {
       qs: {
         uploadType: 'multipart',
       },
+      maxRetries: 0,
     };
 
     const metadata = options.metadata || {};
@@ -617,7 +619,7 @@ export class Util {
    * @param {function} callback - The callback function.
    */
   makeRequest(
-      reqOpts: r.Options, config: MakeRequestConfig,
+      reqOpts: DecorateRequestOptions, config: MakeRequestConfig,
       callback: BodyResponseCallback): void|Abortable {
     const options = {
       request: (config.request as typeof r).defaults(requestDefaults),
@@ -627,6 +629,10 @@ export class Util {
         return err && util.shouldRetryRequest(err);
       },
     } as {} as retryRequest.Options;
+
+    if (is.number(reqOpts.maxRetries)) {
+      options.retries = reqOpts.maxRetries;
+    }
 
     if (!config.stream) {
       return retryRequest(reqOpts, options, (err, response, body) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -630,7 +630,7 @@ export class Util {
       },
     } as {} as retryRequest.Options;
 
-    if (is.number(reqOpts.maxRetries)) {
+    if (typeof reqOpts.maxRetries === 'number') {
       options.retries = reqOpts.maxRetries;
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -149,7 +149,7 @@ export interface MakeWritableStreamOptions {
   }): void;
 }
 
-export interface DecorateRequestOptions extends r.Options {
+export interface DecorateRequestOptions extends r.CoreOptions {
   autoPaginate?: boolean;
   autoPaginateVal?: boolean;
   objectMode?: boolean;

--- a/src/util.ts
+++ b/src/util.ts
@@ -149,7 +149,7 @@ export interface MakeWritableStreamOptions {
   }): void;
 }
 
-export interface DecorateRequestOptions extends r.OptionsWithUri {
+export interface DecorateRequestOptions extends r.Options {
   autoPaginate?: boolean;
   autoPaginateVal?: boolean;
   objectMode?: boolean;

--- a/system-test/fixtures/kitchen/src/index.ts
+++ b/system-test/fixtures/kitchen/src/index.ts
@@ -4,7 +4,7 @@ import {GoogleAuthOptions, Operation,Service, ServiceConfig, ServiceOptions,
   ServiceObjectConfig, StreamRequestOptions, Abortable, AbortableDuplex,
   ApiError, util} from '@google-cloud/common';
 
-util.makeRequest({url: 'test'}, {}, (err, body, res) => {
+util.makeRequest({uri: 'test'}, {}, (err, body, res) => {
   console.log(err);
 });
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/27
Fixes https://github.com/googleapis/nodejs-storage/issues/312

Previously, we were retrying streaming POST requests, in places like `file.createWriteStream()`. That's not actually possible, since once the data has left the user's stream, and we pass it to the upstream API, it's effectively gone to free up memory. So if suddenly the API decides it's upset, we can't rewind the state of the transfer.