### PR TITLE
Remove 'is' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "ent": "^2.2.0",
     "extend": "^3.0.1",
     "google-auth-library": "^2.0.0",
-    "is": "^3.2.1",
     "pify": "^4.0.0",
     "retry-request": "^4.0.0",
     "through2": "^2.0.3"
@@ -79,7 +78,6 @@
     "@types/arrify": "^1.0.4",
     "@types/ent": "^2.2.1",
     "@types/extend": "^3.0.0",
-    "@types/is": "0.0.20",
     "@types/mocha": "^5.2.1",
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -22,7 +22,6 @@ import {promisifyAll} from '@google-cloud/promisify';
 import * as arrify from 'arrify';
 import {EventEmitter} from 'events';
 import * as extend from 'extend';
-import * as is from 'is';
 import * as r from 'request';  // Only needed for type declarations.
 
 import {StreamRequestOptions} from '.';
@@ -308,7 +307,7 @@ class ServiceObject extends EventEmitter {
       config = configOrCallback;
     }
 
-    const autoCreate = config.autoCreate && is.fn(this.create);
+    const autoCreate = config.autoCreate && typeof this.create === 'function';
     delete config.autoCreate;
 
     function onCreate(
@@ -330,7 +329,7 @@ class ServiceObject extends EventEmitter {
       if (err) {
         if (err.code === 404 && autoCreate) {
           const args: Array<Function|GetConfig> = [];
-          if (!is.empty(config)) {
+          if (Object.keys(config).length > 0) {
             args.push(config);
           }
           args.push(onCreate);

--- a/src/service.ts
+++ b/src/service.ts
@@ -21,7 +21,6 @@
 import * as arrify from 'arrify';
 import * as extend from 'extend';
 import {GoogleAuth} from 'google-auth-library';
-import * as is from 'is';
 import * as pify from 'pify';
 import * as r from 'request';  // Only needed for type declarations.
 import {BodyResponseCallback, DecorateRequestOptions, MakeAuthenticatedRequest, PackageJson, util} from './util';
@@ -225,7 +224,7 @@ export class Service {
                 return args.length > 1 ? args[1] : null;
               },
               e => {
-                if (is.array(e) && e.length > 0) {
+                if (Array.isArray(e) && e.length > 0) {
                   const [err, body, res] = e;
                   if (res) {
                     res.body = err;

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,6 @@ import * as ent from 'ent';
 import * as extend from 'extend';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import {CredentialBody} from 'google-auth-library/build/src/auth/credentials';
-import * as is from 'is';
 import * as r from 'request';
 import * as retryRequest from 'retry-request';
 import * as through from 'through2';
@@ -340,7 +339,7 @@ export class Util {
       body,
     };
 
-    if (is.string(body)) {
+    if (typeof body === 'string') {
       try {
         parsedHttpRespBody.body = JSON.parse(body);
       } catch (err) {
@@ -669,19 +668,19 @@ export class Util {
     delete reqOpts.autoPaginateVal;
     delete reqOpts.objectMode;
 
-    if (is.object(reqOpts.qs)) {
+    if (reqOpts.qs !== null && typeof reqOpts.qs === 'object') {
       delete reqOpts.qs.autoPaginate;
       delete reqOpts.qs.autoPaginateVal;
       reqOpts.qs = replaceProjectIdToken(reqOpts.qs, projectId);
     }
 
-    if (is.array(reqOpts.multipart)) {
+    if (Array.isArray(reqOpts.multipart)) {
       reqOpts.multipart = (reqOpts.multipart as []).map(part => {
         return replaceProjectIdToken(part, projectId);
       });
     }
 
-    if (is.object(reqOpts.json)) {
+    if (reqOpts.json !== null && typeof reqOpts.json === 'object') {
       delete reqOpts.json.autoPaginate;
       delete reqOpts.json.autoPaginateVal;
       reqOpts.json = replaceProjectIdToken(reqOpts.json, projectId);


### PR DESCRIPTION
All of these replacements are synonymous with `is`'s implementations -- all of `is`'s tests pass using these versions.

Closes #163

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
