### PR TITLE
fix: improve types for service object

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -22,7 +22,8 @@ import * as pify from 'pify';
 
 import {GetMetadataCallback, ServiceObject, ServiceObjectConfig} from './service-object';
 
-export class Operation extends ServiceObject {
+// tslint:disable-next-line no-any
+export class Operation<T=any> extends ServiceObject<T> {
   completeListeners: number;
   hasActiveListeners: boolean;
 

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -25,7 +25,10 @@ import * as extend from 'extend';
 import * as r from 'request';  // Only needed for type declarations.
 
 import {StreamRequestOptions} from '.';
+import {Operation} from './operation';
 import {ApiError, BodyResponseCallback, DecorateRequestOptions, util} from './util';
+
+export type CreateOptions = {};
 
 export interface ServiceObjectParent {
   // tslint:disable-next-line:variable-name
@@ -90,9 +93,15 @@ export interface Methods {
   [methodName: string]: {reqOpts?: r.CoreOptions}|boolean;
 }
 
-export interface InstanceResponseCallback {
-  (err: ApiError|null, instance?: ServiceObject|null,
-   apiResponse?: r.Response): void;
+export interface InstanceResponseCallback<T> {
+  (err: ApiError|null, instance?: T|null, apiResponse?: r.Response): void;
+}
+
+// tslint:disable-next-line no-any
+export type CreateResponse<T> = [T, ...any[]];
+export interface CreateCallback<T> {
+  // tslint:disable-next-line no-any
+  (err: ApiError|null, instance?: T|null, ...args: any[]): void;
 }
 
 export interface DeleteCallback {
@@ -111,8 +120,7 @@ export interface ResponseCallback {
 }
 
 export type SetMetadataResponse = [r.Response];
-
-export type GetResponse = [ServiceObject, r.Response];
+export type GetResponse<T> = [T, r.Response];
 
 /**
  * ServiceObject is a base class, meant to be inherited from by a "service
@@ -125,7 +133,8 @@ export type GetResponse = [ServiceObject, r.Response];
  * shared behaviors. Note that any method can be overridden when the service
  * object requires specific behavior.
  */
-class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
+// tslint:disable-next-line no-any
+class ServiceObject<T = any> extends EventEmitter {
   metadata: Metadata;
   baseUrl?: string;
   parent: ServiceObjectParent;
@@ -135,8 +144,6 @@ class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
   protected interceptors: Interceptor[];
   // tslint:disable-next-line:variable-name
   Promise?: PromiseConstructor;
-  // tslint:disable-next-line:no-any
-  [index: string]: any;
   requestModule: typeof r;
 
   /*
@@ -178,12 +185,16 @@ class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
                 !/^request/.test(methodName) &&
                 // clang-format on
                 // The ServiceObject didn't redefine the method.
-                this[methodName] === ServiceObject.prototype[methodName] &&
+                // tslint:disable-next-line no-any
+                (this as any)[methodName] ===
+                    // tslint:disable-next-line no-any
+                    (ServiceObject.prototype as any)[methodName] &&
                 // This method isn't wanted.
                 !config.methods![methodName]);
           })
           .forEach(methodName => {
-            this[methodName] = undefined;
+            // tslint:disable-next-line no-any
+            (this as any)[methodName] = undefined;
           });
     }
   }
@@ -197,18 +208,17 @@ class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
    * @param {object} callback.instance - The instance.
    * @param {object} callback.apiResponse - The full API response.
    */
-  create(options?: CreateOptions): Promise<[ServiceObject, r.Response]>;
-  create(options: CreateOptions, callback: InstanceResponseCallback): void;
-  create(callback: InstanceResponseCallback): void;
+  create(options?: CreateOptions): Promise<CreateResponse<T>>;
+  create(options: CreateOptions, callback: CreateCallback<T>): void;
+  create(callback: CreateCallback<T>): void;
   create(
-      optionsOrCallback?: CreateOptions|InstanceResponseCallback,
-      callback?: InstanceResponseCallback):
-      void|Promise<[ServiceObject, r.Response]> {
+      optionsOrCallback?: CreateOptions|CreateCallback<T>,
+      callback?: CreateCallback<T>): void|Promise<CreateResponse<T>> {
     const self = this;
     const args = [this.id] as Array<{}>;
 
     if (typeof optionsOrCallback === 'function') {
-      callback = optionsOrCallback as InstanceResponseCallback;
+      callback = optionsOrCallback as CreateCallback<T>;
     }
 
     if (typeof optionsOrCallback === 'object') {
@@ -217,10 +227,10 @@ class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
 
     // Wrap the callback to return *this* instance of the object, not the
     // newly-created one.
-    function onCreate(err: Error, instance: ServiceObject) {
+    function onCreate(err: Error, instance: T) {
       const args = [].slice.call(arguments);
       if (!err) {
-        self.metadata = instance.metadata;
+        self.metadata = (instance as {} as ServiceObject<T>).metadata;
         args[1] = self;  // replace the created `instance` with this one.
       }
       callback!.apply(null, args);
@@ -228,6 +238,7 @@ class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
     args.push(onCreate);
     this.createMethod!.apply(null, args);
   }
+
 
   /**
    * Delete the object.
@@ -290,17 +301,17 @@ class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
    * @param {object} callback.instance - The instance.
    * @param {object} callback.apiResponse - The full API response.
    */
-  get(config?: GetConfig&CreateOptions): Promise<GetResponse>;
-  get(callback: InstanceResponseCallback): void;
+  get(config?: GetConfig&CreateOptions): Promise<GetResponse<T>>;
+  get(callback: InstanceResponseCallback<T>): void;
   get(config: GetConfig&CreateOptions,
-      callback: InstanceResponseCallback): void;
-  get(arg0?: (GetConfig&CreateOptions)|InstanceResponseCallback,
-      arg1?: InstanceResponseCallback): void|Promise<GetResponse> {
+      callback: InstanceResponseCallback<T>): void;
+  get(arg0?: (GetConfig&CreateOptions)|InstanceResponseCallback<T>,
+      arg1?: InstanceResponseCallback<T>): void|Promise<GetResponse<T>> {
     const self = this;
 
-    let callback: InstanceResponseCallback = arg1 as InstanceResponseCallback;
+    let callback = arg1;
     if (typeof arg0 === 'function') {
-      callback = arg0 as InstanceResponseCallback;
+      callback = arg0;
     }
 
     let config: GetConfig&CreateOptions = {} as GetConfig & CreateOptions;
@@ -312,17 +323,16 @@ class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
     delete config.autoCreate;
 
     function onCreate(
-        err: ApiError|null, instance: ServiceObject, apiResponse: r.Response) {
+        err: ApiError|null, instance: T, apiResponse: r.Response) {
       if (err) {
         if (err.code === 409) {
           self.get(config, callback!);
           return;
         }
-        callback(err, null, apiResponse);
+        callback!(err, null, apiResponse);
         return;
       }
-
-      callback(null, instance, apiResponse);
+      callback!(null, instance, apiResponse);
     }
 
     this.getMetadata((e, metadata) => {
@@ -337,10 +347,10 @@ class ServiceObject<CreateOptions extends {} = {}> extends EventEmitter {
           self.create.apply(self, args);
           return;
         }
-        callback(err, null, metadata as r.Response);
+        callback!(err, null, metadata as r.Response);
         return;
       }
-      callback(null, self, metadata as r.Response);
+      callback!(null, self as {} as T, metadata as r.Response);
     });
   }
 

--- a/test/operation.ts
+++ b/test/operation.ts
@@ -80,12 +80,10 @@ describe('Operation', () => {
     });
 
     it('should call listenForEvents_', () => {
-      let called = false;
-      sandbox.stub(Operation.prototype, 'listenForEvents_').callsFake(() => {
-        called = true;
-      });
+      // tslint:disable-next-line no-any
+      const stub = sandbox.stub(Operation.prototype as any, 'listenForEvents_');
       const op = new Operation({} as ServiceObjectConfig);
-      assert.strictEqual(called, true);
+      assert.ok(stub.called);
     });
   });
 
@@ -245,8 +243,8 @@ describe('Operation', () => {
 
   describe('startPolling_', () => {
     beforeEach(() => {
-      sandbox.stub(Operation.prototype, 'listenForEvents_')
-          .callsFake(util.noop);
+      // tslint:disable-next-line no-any
+      sandbox.stub(Operation.prototype as any, 'listenForEvents_');
       operation.hasActiveListeners = true;
     });
 


### PR DESCRIPTION
This improves the types for the create method on service-object, dumps a spurious `any` index property, and adds generic support.