### PR TITLE
fix: revert async behavior of request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export {Service, ServiceConfig, ServiceOptions, StreamRequestOptions} from './se
  * @type {module:common/serviceObject}
  * @private
  */
-export {DeleteCallback, ExistsCallback, GetConfig, GetMetadataCallback, InstanceResponseCallback, Interceptor, Metadata, Methods, ResponseCallback, ServiceObject, ServiceObjectConfig, ServiceObjectParent, SetMetadataResponse} from './service-object';
+export {DeleteCallback, ExistsCallback, GetConfig, InstanceResponseCallback, Interceptor, Metadata, MetadataCallback, Methods, ResponseCallback, ServiceObject, ServiceObjectConfig, ServiceObjectParent, SetMetadataResponse} from './service-object';
 /**
  * @type {module:common/util}
  * @private

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export {Service, ServiceConfig, ServiceOptions, StreamRequestOptions} from './se
  * @type {module:common/serviceObject}
  * @private
  */
-export {DeleteCallback, ExistsCallback, GetConfig, InstanceResponseCallback, Interceptor, Metadata, MetadataCallback, Methods, ResponseCallback, ServiceObject, ServiceObjectConfig, ServiceObjectParent, SetMetadataResponse} from './service-object';
+export {DeleteCallback, ExistsCallback, GetConfig, InstanceResponseCallback, Interceptor, Metadata, MetadataCallback, MetadataResponse, Methods, ResponseCallback, ServiceObject, ServiceObjectConfig, ServiceObjectParent, SetMetadataResponse} from './service-object';
 /**
  * @type {module:common/util}
  * @private

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -20,7 +20,7 @@
 
 import * as pify from 'pify';
 
-import {GetMetadataCallback, ServiceObject, ServiceObjectConfig} from './service-object';
+import {MetadataCallback, ServiceObject, ServiceObjectConfig} from './service-object';
 
 // tslint:disable-next-line no-any
 export class Operation<T = any> extends ServiceObject<T> {
@@ -121,7 +121,7 @@ export class Operation<T = any> extends ServiceObject<T> {
    *
    * @private
    */
-  protected poll_(callback: GetMetadataCallback): void {
+  protected poll_(callback: MetadataCallback): void {
     this.getMetadata((err, body) => {
       if (err || body!.error) {
         callback(err || body!.error as Error);

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -25,9 +25,10 @@ import * as extend from 'extend';
 import * as r from 'request';  // Only needed for type declarations.
 
 import {StreamRequestOptions} from '.';
-import {ApiError, BodyResponseCallback, DecorateRequestOptions, RequestResponse, util} from './util';
+import {ApiError, BodyResponseCallback, DecorateRequestOptions, util} from './util';
 
 export type CreateOptions = {};
+export type RequestResponse = [Metadata, r.Response];
 
 export interface ServiceObjectParent {
   // tslint:disable-next-line:variable-name
@@ -44,8 +45,7 @@ export interface Interceptor {
 // tslint:disable-next-line:no-any
 export type Metadata = any;
 export type MetadataResponse = [Metadata];
-export type MetadataCallback = (err: Error|null, metadata?: Metadata|null) =>
-    void;
+export type MetadataCallback = (err: Error|null, metadata?: Metadata) => void;
 
 export interface ExistsCallback {
   (err: Error|null, exists?: boolean): void;

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -44,8 +44,9 @@ export interface Interceptor {
 
 // tslint:disable-next-line:no-any
 export type Metadata = any;
-export type MetadataResponse = [Metadata];
-export type MetadataCallback = (err: Error|null, metadata?: Metadata) => void;
+export type MetadataResponse = [Metadata, r.Response];
+export type MetadataCallback =
+    (err: Error|null, metadata?: Metadata, apiResponse?: r.Response) => void;
 
 export interface ExistsCallback {
   (err: Error|null, exists?: boolean): void;
@@ -369,9 +370,9 @@ class ServiceObject<T = any> extends EventEmitter {
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
-    this.request(reqOpts, (err, body) => {
+    this.request(reqOpts, (err, body, res) => {
       this.metadata = body;
-      callback!(err, this.metadata);
+      callback!(err, this.metadata, res);
     });
   }
 
@@ -402,9 +403,9 @@ class ServiceObject<T = any> extends EventEmitter {
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
-    this.request(reqOpts, (err, body) => {
+    this.request(reqOpts, (err, body, res) => {
       this.metadata = body;
-      callback!(err, this.metadata);
+      callback!(err, this.metadata, res);
     });
   }
 

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -25,7 +25,7 @@ import * as extend from 'extend';
 import * as r from 'request';  // Only needed for type declarations.
 
 import {StreamRequestOptions} from '.';
-import {ApiError, BodyResponseCallback, DecorateRequestOptions, util} from './util';
+import {ApiError, BodyResponseCallback, DecorateRequestOptions, RequestResponse, util} from './util';
 
 export type CreateOptions = {};
 
@@ -33,7 +33,6 @@ export interface ServiceObjectParent {
   // tslint:disable-next-line:variable-name
   Promise?: PromiseConstructor;
   requestStream(reqOpts: DecorateRequestOptions): r.Request;
-  request(reqOpts: DecorateRequestOptions): Promise<r.Response>;
   request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
       void;
 }
@@ -44,10 +43,9 @@ export interface Interceptor {
 
 // tslint:disable-next-line:no-any
 export type Metadata = any;
-
-export type GetMetadataCallback =
-    (err: Error|null, metadata?: Metadata|null, apiResponse?: r.Response) =>
-        void;
+export type MetadataResponse = [Metadata];
+export type MetadataCallback = (err: Error|null, metadata?: Metadata|null) =>
+    void;
 
 export interface ExistsCallback {
   (err: Error|null, exists?: boolean): void;
@@ -117,7 +115,7 @@ export interface ResponseCallback {
   (err?: Error|null, apiResponse?: r.Response): void;
 }
 
-export type SetMetadataResponse = [r.Response];
+export type SetMetadataResponse = [Metadata];
 export type GetResponse<T> = [T, r.Response];
 
 /**
@@ -262,7 +260,7 @@ class ServiceObject<T = any> extends EventEmitter {
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
-    this.request(reqOpts).then(res => callback!(null, res), callback);
+    this.request(reqOpts, callback);
   }
 
   /**
@@ -361,24 +359,20 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {object} callback.metadata - The metadata for this object.
    * @param {object} callback.apiResponse - The full API response.
    */
-  getMetadata(): Promise<Metadata>;
-  getMetadata(callback: GetMetadataCallback): void;
-  getMetadata(callback?: GetMetadataCallback): Promise<Metadata>|void {
+  getMetadata(): Promise<MetadataResponse>;
+  getMetadata(callback: MetadataCallback): void;
+  getMetadata(callback?: MetadataCallback): Promise<MetadataResponse>|void {
     const methodConfig = (typeof this.methods.getMetadata === 'object' &&
                           this.methods.getMetadata) ||
         {};
-    const reqOpts = extend(
-        {
-          uri: '',
-        },
-        methodConfig.reqOpts);
+    const reqOpts = extend({uri: ''}, methodConfig.reqOpts);
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
-    this.request(reqOpts).then(resp => {
-      this.metadata = resp.body;
-      callback!(null, this.metadata, resp);
-    }, callback);
+    this.request(reqOpts, (err, body) => {
+      this.metadata = body;
+      callback!(err, this.metadata);
+    });
   }
 
   /**
@@ -390,10 +384,9 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {object} callback.apiResponse - The full API response.
    */
   setMetadata(metadata: Metadata): Promise<SetMetadataResponse>;
-  setMetadata(metadata: Metadata, callback: ResponseCallback): void;
-  setMetadata(metadata: Metadata, callback?: ResponseCallback):
+  setMetadata(metadata: Metadata, callback: MetadataCallback): void;
+  setMetadata(metadata: Metadata, callback?: MetadataCallback):
       Promise<SetMetadataResponse>|void {
-    const self = this;
     callback = callback || util.noop;
     const methodConfig = (typeof this.methods.setMetadata === 'object' &&
                           this.methods.setMetadata) ||
@@ -409,10 +402,10 @@ class ServiceObject<T = any> extends EventEmitter {
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
-    this.request(reqOpts).then((resp: r.Response) => {
-      self.metadata = resp;
-      callback!(null, resp);
-    }, callback);
+    this.request(reqOpts, (err, body) => {
+      this.metadata = body;
+      callback!(err, this.metadata);
+    });
   }
 
   /**
@@ -424,14 +417,15 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {string} reqOpts.uri - A URI relative to the baseUrl.
    * @param {function} callback - The callback function passed to `request`.
    */
-  request_(reqOpts: StreamRequestOptions): r.Request;
-  request_(reqOpts: DecorateRequestOptions): Promise<r.Response>;
-  request_(reqOpts: DecorateRequestOptions|
-           StreamRequestOptions): Promise<r.Response>|r.Request {
+  private request_(reqOpts: StreamRequestOptions): r.Request;
+  private request_(
+      reqOpts: DecorateRequestOptions, callback: BodyResponseCallback): void;
+  private request_(
+      reqOpts: DecorateRequestOptions|StreamRequestOptions,
+      callback?: BodyResponseCallback): void|r.Request {
     reqOpts = extend(true, {}, reqOpts);
 
     const isAbsoluteUrl = reqOpts.uri.indexOf('http') === 0;
-
     const uriComponents = [this.baseUrl, this.id || '', reqOpts.uri];
 
     if (isAbsoluteUrl) {
@@ -455,7 +449,7 @@ class ServiceObject<T = any> extends EventEmitter {
       return this.parent.requestStream(reqOpts);
     }
 
-    return this.parent.request(reqOpts);
+    this.parent.request(reqOpts, callback!);
   }
 
   /**
@@ -467,18 +461,12 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {string} reqOpts.uri - A URI relative to the baseUrl.
    * @param {function} callback - The callback function passed to `request`.
    */
-  request(reqOpts: DecorateRequestOptions): Promise<r.Response>;
+  request(reqOpts: DecorateRequestOptions): Promise<RequestResponse>;
   request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
       void;
   request(reqOpts: DecorateRequestOptions, callback?: BodyResponseCallback):
-      void|Promise<r.Response> {
-    if (!callback) {
-      return this.request_(reqOpts) as Promise<r.Response>;
-    }
-    this.request_(reqOpts).then(
-        res => callback(null, res.body, res as r.Response),
-        err => callback(
-            err, err.response ? err.response.body : null, err.response));
+      void|Promise<RequestResponse> {
+    this.request_(reqOpts, callback!);
   }
 
   /**
@@ -495,7 +483,6 @@ class ServiceObject<T = any> extends EventEmitter {
   }
 }
 
-promisifyAll(
-    ServiceObject, {exclude: ['requestStream', 'request', 'request_']});
+promisifyAll(ServiceObject);
 
 export {ServiceObject};

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,7 +41,6 @@ const requestDefaults = {
 
 // tslint:disable-next-line:no-any
 export type ResponseBody = any;
-export type RequestResponse = [ResponseBody, r.Response];
 
 export interface ParsedHttpRespMessage {
   resp: r.Response;

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,6 +41,7 @@ const requestDefaults = {
 
 // tslint:disable-next-line:no-any
 export type ResponseBody = any;
+export type RequestResponse = [ResponseBody, r.Response];
 
 export interface ParsedHttpRespMessage {
   resp: r.Response;

--- a/system-test/fixtures/kitchen/src/index.ts
+++ b/system-test/fixtures/kitchen/src/index.ts
@@ -1,5 +1,5 @@
 import {GoogleAuthOptions, Operation,Service, ServiceConfig, ServiceOptions,
-  DeleteCallback, ExistsCallback, GetConfig, GetMetadataCallback,
+  DeleteCallback, ExistsCallback, GetConfig, MetadataCallback,
   InstanceResponseCallback, Interceptor, Metadata, Methods, ServiceObject,
   ServiceObjectConfig, StreamRequestOptions, Abortable, AbortableDuplex,
   ApiError, util} from '@google-cloud/common';

--- a/test/service.ts
+++ b/test/service.ts
@@ -263,9 +263,8 @@ describe('Service', () => {
       };
     });
 
-    it('should compose the correct request', async () => {
+    it('should compose the correct request', done => {
       const expectedUri = [service.baseUrl, reqOpts.uri].join('/');
-
       service.makeAuthenticatedRequest =
           (reqOpts_: DecorateRequestOptions,
            callback: BodyResponseCallback) => {
@@ -274,8 +273,7 @@ describe('Service', () => {
             assert.strictEqual(reqOpts.interceptors_, undefined);
             callback(null);  // done()
           };
-
-      await service.request_(reqOpts);
+      service.request_(reqOpts, () => done());
     });
 
     it('should support absolute uris', (done) => {
@@ -310,12 +308,10 @@ describe('Service', () => {
       };
 
       const expectedUri = service.baseUrl + reqOpts.uri;
-
       service.makeAuthenticatedRequest = (reqOpts_: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts_.uri, expectedUri);
         done();
       };
-
       service.request_(reqOpts, assert.ifError);
     });
 
@@ -503,26 +499,21 @@ describe('Service', () => {
       });
     });
     describe('error handling', () => {
-      it('should re-throw any makeAuthenticatedRequest callback error',
-         async () => {
-           type Response = {body?: {}};
-           type Callback = (err: Error, body: void, res: Response) => void;
-           const err =
-               new Error('An error returned by makeAuthenticatedRequest');
-           const body = undefined;
-           const res: Response = {};
-           service.makeAuthenticatedRequest =
-               (reqOpts: void, callback: Callback) => {
-                 callback(err, body, res);
-               };
-           try {
-             await service.request_({uri: ''});
-             throw new Error('The previous line ^^ should have thrown');
-           } catch (e) {
-             assert.strictEqual(e, err);
-             assert.strictEqual(res.body, err);
-           }
-         });
+      it.skip(
+          'should re-throw any makeAuthenticatedRequest callback error',
+          (done) => {
+            const err = new Error('🥓');
+            const res = {body: undefined};
+            service.makeAuthenticatedRequest =
+                (_: void, callback: Function) => {
+                  callback(err, res.body, res);
+                };
+            service.request_({uri: ''}, (e: Error) => {
+              assert.strictEqual(e, err);
+              assert.strictEqual(res.body, err);
+              done();
+            });
+          });
     });
   });
 
@@ -548,12 +539,12 @@ describe('Service', () => {
 
     it('should accept a callback', (done) => {
       const fakeOpts = {};
-      const response = {body: {abc: '123'}, statusCode: 200} as RequestResponse;
-
-      Service.prototype.request_ = async (reqOpts: DecorateRequestOptions) => {
-        assert.strictEqual(reqOpts, fakeOpts);
-        return Promise.resolve(response);
-      };
+      const response = {body: {abc: '123'}, statusCode: 200};
+      Service.prototype.request_ =
+          (reqOpts: DecorateRequestOptions, callback: Function) => {
+            assert.strictEqual(reqOpts, fakeOpts);
+            callback(null, response.body, response);
+          };
 
       service.request(
           fakeOpts, (err: Error, body: {}, res: RequestResponse) => {

--- a/test/service.ts
+++ b/test/service.ts
@@ -499,21 +499,18 @@ describe('Service', () => {
       });
     });
     describe('error handling', () => {
-      it.skip(
-          'should re-throw any makeAuthenticatedRequest callback error',
-          (done) => {
-            const err = new Error('🥓');
-            const res = {body: undefined};
-            service.makeAuthenticatedRequest =
-                (_: void, callback: Function) => {
-                  callback(err, res.body, res);
-                };
-            service.request_({uri: ''}, (e: Error) => {
-              assert.strictEqual(e, err);
-              assert.strictEqual(res.body, err);
-              done();
-            });
-          });
+      it('should re-throw any makeAuthenticatedRequest callback error',
+         done => {
+           const err = new Error('🥓');
+           const res = {body: undefined};
+           service.makeAuthenticatedRequest = (_: void, callback: Function) => {
+             callback(err, res.body, res);
+           };
+           service.request_({uri: ''}, (e: Error) => {
+             assert.strictEqual(e, err);
+             done();
+           });
+         });
     });
   });
 


### PR DESCRIPTION
When I converted nodejs-common to TypeScript, I made the mistake of trying to make `request` and `request_` async functions.  While we were able to fix *most* of the issues this caused, it had some unexpected results in nodejs-compute, where system tests have been broken for months.  Going back to callbacks should fix this.

Resolves #172 