### PR TITLE
fix: flip order of request callback params

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,4 +34,4 @@ export {DeleteCallback, ExistsCallback, GetConfig, InstanceResponseCallback, Int
  * @type {module:common/util}
  * @private
  */
-export {Abortable, AbortableDuplex, ApiError, BodyResponseCallback, DecorateRequestOptions, ResponseBody, util} from './util';
+export {Abortable, AbortableDuplex, ApiError, DecorateRequestOptions, ResponseBody, util} from './util';

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export {Service, ServiceConfig, ServiceOptions, StreamRequestOptions} from './se
  * @type {module:common/serviceObject}
  * @private
  */
-export {DeleteCallback, ExistsCallback, GetConfig, InstanceResponseCallback, Interceptor, Metadata, MetadataCallback, MetadataResponse, Methods, ResponseCallback, ServiceObject, ServiceObjectConfig, ServiceObjectParent, SetMetadataResponse} from './service-object';
+export {DeleteCallback, ExistsCallback, GetConfig, GetMetadataCallback, GetMetadataResponse, InstanceResponseCallback, Interceptor, Metadata, Methods, ResponseCallback, ServiceObject, ServiceObjectConfig, ServiceObjectParent, SetMetadataCallback, SetMetadataResponse} from './service-object';
 /**
  * @type {module:common/util}
  * @private

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -20,7 +20,7 @@
 
 import * as pify from 'pify';
 
-import {MetadataCallback, ServiceObject, ServiceObjectConfig} from './service-object';
+import {GetMetadataCallback, ServiceObject, ServiceObjectConfig} from './service-object';
 
 // tslint:disable-next-line no-any
 export class Operation<T = any> extends ServiceObject<T> {
@@ -121,7 +121,7 @@ export class Operation<T = any> extends ServiceObject<T> {
    *
    * @private
    */
-  protected poll_(callback: MetadataCallback): void {
+  protected poll_(callback: GetMetadataCallback): void {
     this.getMetadata((err, body) => {
       if (err || body!.error) {
         callback(err || body!.error as Error);

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -25,17 +25,16 @@ import * as extend from 'extend';
 import * as r from 'request';  // Only needed for type declarations.
 
 import {StreamRequestOptions} from '.';
-import {ApiError, BodyResponseCallback, DecorateRequestOptions, util} from './util';
+import {ApiError, DecorateRequestOptions, util} from './util';
 
 export type CreateOptions = {};
-export type RequestResponse = [Metadata, r.Response];
+export type RequestResponse = [r.Response, Metadata];
 
 export interface ServiceObjectParent {
   // tslint:disable-next-line:variable-name
   Promise?: PromiseConstructor;
   requestStream(reqOpts: DecorateRequestOptions): r.Request;
-  request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
-      void;
+  request(reqOpts: DecorateRequestOptions, callback: r.RequestCallback): void;
 }
 
 export interface Interceptor {
@@ -420,10 +419,10 @@ class ServiceObject<T = any> extends EventEmitter {
    */
   private request_(reqOpts: StreamRequestOptions): r.Request;
   private request_(
-      reqOpts: DecorateRequestOptions, callback: BodyResponseCallback): void;
+      reqOpts: DecorateRequestOptions, callback: r.RequestCallback): void;
   private request_(
       reqOpts: DecorateRequestOptions|StreamRequestOptions,
-      callback?: BodyResponseCallback): void|r.Request {
+      callback?: r.RequestCallback): void|r.Request {
     reqOpts = extend(true, {}, reqOpts);
 
     const isAbsoluteUrl = reqOpts.uri.indexOf('http') === 0;
@@ -463,9 +462,8 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {function} callback - The callback function passed to `request`.
    */
   request(reqOpts: DecorateRequestOptions): Promise<RequestResponse>;
-  request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
-      void;
-  request(reqOpts: DecorateRequestOptions, callback?: BodyResponseCallback):
+  request(reqOpts: DecorateRequestOptions, callback: r.RequestCallback): void;
+  request(reqOpts: DecorateRequestOptions, callback?: r.RequestCallback):
       void|Promise<RequestResponse> {
     this.request_(reqOpts, callback!);
   }

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -43,8 +43,11 @@ export interface Interceptor {
 
 // tslint:disable-next-line:no-any
 export type Metadata = any;
-export type MetadataResponse = [Metadata, r.Response];
-export type MetadataCallback =
+export type GetMetadataResponse = [Metadata, r.Response];
+export type GetMetadataCallback =
+    (err: Error|null, metadata?: Metadata, apiResponse?: r.Response) => void;
+export type SetMetadataResponse = [r.Response];
+export type SetMetadataCallback =
     (err: Error|null, metadata?: Metadata, apiResponse?: r.Response) => void;
 
 export interface ExistsCallback {
@@ -115,7 +118,6 @@ export interface ResponseCallback {
   (err?: Error|null, apiResponse?: r.Response): void;
 }
 
-export type SetMetadataResponse = [Metadata];
 export type GetResponse<T> = [T, r.Response];
 
 /**
@@ -359,9 +361,10 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {object} callback.metadata - The metadata for this object.
    * @param {object} callback.apiResponse - The full API response.
    */
-  getMetadata(): Promise<MetadataResponse>;
-  getMetadata(callback: MetadataCallback): void;
-  getMetadata(callback?: MetadataCallback): Promise<MetadataResponse>|void {
+  getMetadata(): Promise<GetMetadataResponse>;
+  getMetadata(callback: GetMetadataCallback): void;
+  getMetadata(callback?: GetMetadataCallback): Promise<GetMetadataResponse>|
+      void {
     const methodConfig = (typeof this.methods.getMetadata === 'object' &&
                           this.methods.getMetadata) ||
         {};
@@ -369,7 +372,7 @@ class ServiceObject<T = any> extends EventEmitter {
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
-    this.request(reqOpts, (err, body, res) => {
+    this.request(reqOpts, (err, res, body) => {
       this.metadata = body;
       callback!(err, this.metadata, res);
     });
@@ -384,8 +387,8 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {object} callback.apiResponse - The full API response.
    */
   setMetadata(metadata: Metadata): Promise<SetMetadataResponse>;
-  setMetadata(metadata: Metadata, callback: MetadataCallback): void;
-  setMetadata(metadata: Metadata, callback?: MetadataCallback):
+  setMetadata(metadata: Metadata, callback: SetMetadataCallback): void;
+  setMetadata(metadata: Metadata, callback?: SetMetadataCallback):
       Promise<SetMetadataResponse>|void {
     callback = callback || util.noop;
     const methodConfig = (typeof this.methods.setMetadata === 'object' &&
@@ -402,9 +405,9 @@ class ServiceObject<T = any> extends EventEmitter {
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
-    this.request(reqOpts, (err, body, res) => {
+    this.request(reqOpts, (err, res, body) => {
       this.metadata = body;
-      callback!(err, this.metadata, res);
+      callback!(err, res);
     });
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -24,7 +24,7 @@ import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as r from 'request';  // Only needed for type declarations.
 
 import {Interceptor} from './service-object';
-import {BodyResponseCallback, DecorateRequestOptions, MakeAuthenticatedRequest, PackageJson, util} from './util';
+import {DecorateRequestOptions, MakeAuthenticatedRequest, PackageJson, util} from './util';
 
 const PROJECT_ID_TOKEN = '{{projectId}}';
 
@@ -162,10 +162,10 @@ export class Service {
    */
   private request_(reqOpts: StreamRequestOptions): r.Request;
   private request_(
-      reqOpts: DecorateRequestOptions, callback: BodyResponseCallback): void;
+      reqOpts: DecorateRequestOptions, callback: r.RequestCallback): void;
   private request_(
       reqOpts: DecorateRequestOptions|StreamRequestOptions,
-      callback?: BodyResponseCallback): void|r.Request {
+      callback?: r.RequestCallback): void|r.Request {
     reqOpts = extend(true, {}, reqOpts);
     const isAbsoluteUrl = reqOpts.uri.indexOf('http') === 0;
     const uriComponents = [this.baseUrl];
@@ -231,8 +231,7 @@ export class Service {
    * @param {string} reqOpts.uri - A URI relative to the baseUrl.
    * @param {function} callback - The callback function passed to `request`.
    */
-  request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
-      void {
+  request(reqOpts: DecorateRequestOptions, callback: r.RequestCallback): void {
     this.request_(reqOpts, callback);
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -413,13 +413,13 @@ export class Util {
 
         const request = options.requestModule.defaults(requestDefaults);
         request(authenticatedReqOpts!, (err, resp, body) => {
-          util.handleResp(err, resp, body, (err, data) => {
+          util.handleResp(err, resp, body, (err, parsedResp, body) => {
             if (err) {
               dup.destroy(err);
               return;
             }
             dup.emit('response', resp);
-            onComplete!(data);
+            onComplete!(body);
           });
         });
       },

--- a/src/util.ts
+++ b/src/util.ts
@@ -298,7 +298,7 @@ export class Util {
       parsedResp.resp.body = parsedResp.body;
     }
 
-    callback(parsedResp.err, parsedResp.body, parsedResp.resp);
+    callback(parsedResp.err, parsedResp.resp, parsedResp.body);
   }
 
   /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,10 +52,10 @@ export interface MakeAuthenticatedRequest {
   (reqOpts: DecorateRequestOptions,
    options?: MakeAuthenticatedRequestOptions): void|Abortable;
   (reqOpts: DecorateRequestOptions,
-   callback?: BodyResponseCallback): void|Abortable;
+   callback?: r.RequestCallback): void|Abortable;
   (reqOpts: DecorateRequestOptions,
    optionsOrCallback?: MakeAuthenticatedRequestOptions|
-   BodyResponseCallback): void|Abortable|duplexify.Duplexify;
+   r.RequestCallback): void|Abortable|duplexify.Duplexify;
   getCredentials:
       (callback:
            (err?: Error|null, credentials?: CredentialBody) => void) => void;
@@ -238,10 +238,6 @@ export class PartialFailureError extends Error {
   }
 }
 
-export interface BodyResponseCallback {
-  (err: Error|null, body?: ResponseBody, res?: r.Response): void;
-}
-
 export interface MakeRequestConfig {
   /**
    * Automatically retry requests if the response is related to rate limits or
@@ -289,7 +285,7 @@ export class Util {
    */
   handleResp(
       err: Error|null, resp?: r.Response|null, body?: ResponseBody,
-      callback?: BodyResponseCallback) {
+      callback?: r.RequestCallback) {
     callback = callback || util.noop;
 
     const parsedResp = extend(
@@ -499,12 +495,12 @@ export class Util {
         reqOpts: DecorateRequestOptions,
         options?: MakeAuthenticatedRequestOptions): void|Abortable;
     function makeAuthenticatedRequest(
-        reqOpts: DecorateRequestOptions, callback?: BodyResponseCallback): void|
+        reqOpts: DecorateRequestOptions, callback?: r.RequestCallback): void|
         Abortable;
     function makeAuthenticatedRequest(
         reqOpts: DecorateRequestOptions,
         optionsOrCallback?: MakeAuthenticatedRequestOptions|
-        BodyResponseCallback): void|Abortable|duplexify.Duplexify {
+        r.RequestCallback): void|Abortable|duplexify.Duplexify {
       let stream: duplexify.Duplexify;
       const reqConfig = extend({}, config);
       let activeRequest_: void|Abortable|null;
@@ -625,7 +621,7 @@ export class Util {
    */
   makeRequest(
       reqOpts: DecorateRequestOptions, config: MakeRequestConfig,
-      callback: BodyResponseCallback): void|Abortable {
+      callback: r.RequestCallback): void|Abortable {
     const options = {
       request: (config.request as typeof r).defaults(requestDefaults),
       retries: config.autoRetry !== false ? config.maxRetries || 3 : 0,

--- a/system-test/fixtures/kitchen/src/index.ts
+++ b/system-test/fixtures/kitchen/src/index.ts
@@ -1,10 +1,10 @@
-import {GoogleAuthOptions, Operation,Service, ServiceConfig, ServiceOptions,
-  DeleteCallback, ExistsCallback, GetConfig, MetadataCallback,
+import {GoogleAuthOptions, Operation, Service, ServiceConfig, ServiceOptions,
+  DeleteCallback, ExistsCallback, GetConfig, GetMetadataCallback,
   InstanceResponseCallback, Interceptor, Metadata, Methods, ServiceObject,
   ServiceObjectConfig, StreamRequestOptions, Abortable, AbortableDuplex,
   ApiError, util} from '@google-cloud/common';
 
-util.makeRequest({uri: 'test'}, {}, (err, body, res) => {
+util.makeRequest({uri: 'test'}, {}, (err, res, body) => {
   console.log(err);
 });
 

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -329,7 +329,7 @@ describe('ServiceObject', () => {
   describe('get', () => {
     it('should get the metadata', (done) => {
       serviceObject.getMetadata =
-          promisify((_callback: SO.MetadataCallback): void => {
+          promisify((_callback: SO.GetMetadataCallback): void => {
             done();
           });
 
@@ -338,7 +338,7 @@ describe('ServiceObject', () => {
 
     it('handles not getting a config', (done) => {
       serviceObject.getMetadata =
-          promisify((_callback: SO.MetadataCallback): void => {
+          promisify((_callback: SO.GetMetadataCallback): void => {
             done();
           });
       (serviceObject as FakeServiceObject).get(undefined, assert.ifError);
@@ -348,9 +348,10 @@ describe('ServiceObject', () => {
       const error = new Error('Error.');
       const metadata = {} as SO.Metadata;
 
-      serviceObject.getMetadata = promisify((callback: SO.MetadataCallback) => {
-        callback(error, metadata);
-      });
+      serviceObject.getMetadata =
+          promisify((callback: SO.GetMetadataCallback) => {
+            callback(error, metadata);
+          });
 
       serviceObject.get((err, instance, metadata_) => {
         assert.strictEqual(err, error);
@@ -364,9 +365,10 @@ describe('ServiceObject', () => {
     it('should execute callback with instance & metadata', (done) => {
       const metadata = {} as SO.Metadata;
 
-      serviceObject.getMetadata = promisify((callback: SO.MetadataCallback) => {
-        callback(null, metadata);
-      });
+      serviceObject.getMetadata =
+          promisify((callback: SO.GetMetadataCallback) => {
+            callback(null, metadata);
+          });
 
       serviceObject.get((err, instance, metadata_) => {
         assert.ifError(err);
@@ -391,7 +393,7 @@ describe('ServiceObject', () => {
         };
 
         serviceObject.getMetadata =
-            promisify((callback: SO.MetadataCallback) => {
+            promisify((callback: SO.GetMetadataCallback) => {
               callback(ERROR, METADATA);
             });
       });
@@ -510,24 +512,24 @@ describe('ServiceObject', () => {
     });
 
     it('should update metadata', (done) => {
-      const apiResponse = {};
+      const body = {};
       sandbox.stub(serviceObject, 'request')
-          .callsArgWith(1, null, {}, apiResponse);
+          .callsArgWith(1, null, {body}, body);
       serviceObject.getMetadata(err => {
         assert.ifError(err);
-        assert.deepStrictEqual(serviceObject.metadata, apiResponse);
+        assert.deepStrictEqual(serviceObject.metadata, body);
         done();
       });
     });
 
     it('should execute callback with metadata & API response', (done) => {
-      const apiResponse = {};
-      const requestResponse = {body: apiResponse};
+      const body = {};
+      const response = {body};
       sandbox.stub(serviceObject, 'request')
-          .callsArgWith(1, null, apiResponse, requestResponse);
+          .callsArgWith(1, null, response, body);
       serviceObject.getMetadata((err, metadata) => {
         assert.ifError(err);
-        assert.strictEqual(metadata, apiResponse);
+        assert.strictEqual(metadata, body);
         done();
       });
     });
@@ -585,24 +587,24 @@ describe('ServiceObject', () => {
     });
 
     it('should update metadata', (done) => {
-      const apiResponse = {};
+      const apiResponse = {body: {}};
       sandbox.stub(serviceObject, 'request')
-          .callsArgWith(1, undefined, apiResponse);
-      serviceObject.setMetadata({}, (err) => {
+          .callsArgWith(1, undefined, apiResponse, apiResponse.body);
+      serviceObject.setMetadata({}, err => {
         assert.ifError(err);
-        assert.strictEqual(serviceObject.metadata, apiResponse);
+        assert.strictEqual(serviceObject.metadata, apiResponse.body);
         done();
       });
     });
 
-    it('should execute callback with metadata & API response', (done) => {
+    it('should execute callback with API response', (done) => {
       const body = {};
       const apiResponse = {body};
       sandbox.stub(serviceObject, 'request')
-          .callsArgWith(1, null, body, apiResponse);
-      serviceObject.setMetadata({}, (err, metadata) => {
+          .callsArgWith(1, null, apiResponse, body);
+      serviceObject.setMetadata({}, (err, res) => {
         assert.ifError(err);
-        assert.strictEqual(metadata, body);
+        assert.strictEqual(res, apiResponse);
         done();
       });
     });
@@ -775,8 +777,8 @@ describe('ServiceObject', () => {
     it('should accept a callback', (done) => {
       const response = {body: {abc: '123'}, statusCode: 200} as r.Response;
       sandbox.stub(asInternal(serviceObject), 'request_')
-          .callsArgWith(1, null, response.body, response);
-      serviceObject.request({} as DecorateRequestOptions, (err, body, res) => {
+          .callsArgWith(1, null, response, response.body);
+      serviceObject.request({} as DecorateRequestOptions, (err, res, body) => {
         assert.ifError(err);
         assert.deepStrictEqual(res, response);
         assert.deepStrictEqual(body, response.body);
@@ -791,8 +793,8 @@ describe('ServiceObject', () => {
       // tslint:disable-next-line:no-any
       (err as any).response = response;
       sandbox.stub(asInternal(serviceObject), 'request_')
-          .callsArgWith(1, err, response.body, response);
-      serviceObject.request({} as DecorateRequestOptions, (err, body, res) => {
+          .callsArgWith(1, err, response, response.body);
+      serviceObject.request({} as DecorateRequestOptions, (err, res, body) => {
         assert(err instanceof Error);
         assert.deepStrictEqual(res, response);
         assert.deepStrictEqual(body, response.body);

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -23,14 +23,13 @@ import * as sinon from 'sinon';
 import {Service} from '../src';
 import * as SO from '../src/service-object';
 import {ServiceObject} from '../src/service-object';
-import {ApiError, BodyResponseCallback, DecorateRequestOptions, util} from '../src/util';
+import {ApiError, DecorateRequestOptions, util} from '../src/util';
 
 // tslint:disable-next-line:no-any
 type FakeServiceObject = any;
 type InternalServiceObject = {
-  request_:
-      (reqOpts: DecorateRequestOptions, callback?: BodyResponseCallback) =>
-          void|r.Request;
+  request_: (reqOpts: DecorateRequestOptions, callback?: r.RequestCallback) =>
+      void|r.Request;
   createMethod?: Function; methods: SO.Methods; interceptors: SO.Interceptor[];
 };
 
@@ -63,7 +62,7 @@ describe('ServiceObject', () => {
       const res = {statusCode: 123, body: 'sunny'} as r.Response;
       // tslint:disable-next-line no-any
       (serviceObject as any).request =
-          (opts: {}, callback: BodyResponseCallback) => {
+          (opts: {}, callback: r.RequestCallback) => {
             callback(null, res.body, res);
           };
       const [r] = await serviceObject.delete();
@@ -240,7 +239,7 @@ describe('ServiceObject', () => {
         assert.strictEqual(reqOpts.method, 'DELETE');
         assert.strictEqual(reqOpts.uri, '');
         done();
-        callback(null, null, {} as r.Response);
+        callback(null, {} as r.Response, null);
       });
       serviceObject.delete(assert.ifError);
     });
@@ -260,7 +259,7 @@ describe('ServiceObject', () => {
             assert.strictEqual(reqOpts_.method, method.reqOpts.method);
             assert.deepStrictEqual(reqOpts_.qs, method.reqOpts.qs);
             done();
-            callback(null, null, null!);
+            callback(null, null!, null);
           });
 
       const serviceObject = new ServiceObject(CONFIG) as FakeServiceObject;
@@ -270,7 +269,7 @@ describe('ServiceObject', () => {
 
     it('should not require a callback', () => {
       sandbox.stub(serviceObject, 'request').callsFake((_, callback) => {
-        callback(null, null, {} as r.Response);
+        callback(null, {} as r.Response, {});
       });
       assert.doesNotThrow(() => {
         serviceObject.delete();
@@ -472,7 +471,7 @@ describe('ServiceObject', () => {
             assert.strictEqual(this, serviceObject);
             assert.strictEqual(reqOpts.uri, '');
             done();
-            callback(null, null, {} as r.Response);
+            callback(null, {} as r.Response, null);
           });
       serviceObject.getMetadata(() => {});
     });
@@ -492,7 +491,7 @@ describe('ServiceObject', () => {
             assert.strictEqual(reqOpts_.method, method.reqOpts.method);
             assert.deepStrictEqual(reqOpts_.qs, method.reqOpts.qs);
             done();
-            callback(null, undefined, {} as r.Response);
+            callback(null, {} as r.Response, null);
           });
 
       const serviceObject = new ServiceObject(CONFIG) as FakeServiceObject;
@@ -544,7 +543,7 @@ describe('ServiceObject', () => {
             assert.strictEqual(reqOpts.uri, '');
             assert.strictEqual(reqOpts.json, metadata);
             done();
-            callback(null, null, {} as r.Response);
+            callback(null, {} as r.Response, null);
           });
       serviceObject.setMetadata(metadata);
     });
@@ -570,7 +569,7 @@ describe('ServiceObject', () => {
         assert.deepStrictEqual(reqOpts_.qs, method.reqOpts.qs);
         assert.deepStrictEqual(reqOpts_.json, expectedJson);
         done();
-        callback(null, null, null!);
+        callback(null, null!, null);
       });
       serviceObject.setMetadata(metadata);
     });
@@ -628,7 +627,7 @@ describe('ServiceObject', () => {
         assert.notStrictEqual(reqOpts_, reqOpts);
         assert.strictEqual(reqOpts_.uri, expectedUri);
         assert.deepStrictEqual(reqOpts_.interceptors_, []);
-        callback(null, null, {} as r.Response);
+        callback(null, {} as r.Response, null);
       };
       asInternal(serviceObject).request_(reqOpts, () => done());
     });
@@ -637,7 +636,7 @@ describe('ServiceObject', () => {
       const expectedUri = [serviceObject.baseUrl, reqOpts.uri].join('/');
       serviceObject.parent.request = (reqOpts, callback) => {
         assert.strictEqual(reqOpts.uri, expectedUri);
-        callback(null, null, {} as r.Response);
+        callback(null, {} as r.Response, null);
       };
       serviceObject.id = undefined;
       asInternal(serviceObject).request_(reqOpts, () => done());
@@ -647,7 +646,7 @@ describe('ServiceObject', () => {
       const expectedUri = 'http://www.google.com';
       serviceObject.parent.request = (reqOpts, callback) => {
         assert.strictEqual(reqOpts.uri, expectedUri);
-        callback(null, null, {} as r.Response);
+        callback(null, {} as r.Response, null);
       };
       asInternal(serviceObject).request_({uri: expectedUri}, () => {
         done();
@@ -662,7 +661,7 @@ describe('ServiceObject', () => {
       ].join('/');
       serviceObject.parent.request = (reqOpts_, callback) => {
         assert.strictEqual(reqOpts_.uri, expectedUri);
-        callback(null, null, {} as r.Response);
+        callback(null, {} as r.Response, null);
       };
       asInternal(serviceObject).request_(reqOpts, () => done());
     });
@@ -675,7 +674,7 @@ describe('ServiceObject', () => {
           [serviceObject.baseUrl, serviceObject.id, '1/2'].join('/');
       serviceObject.parent.request = (reqOpts_, callback) => {
         assert.strictEqual(reqOpts_.uri, expectedUri);
-        callback(null, null, {} as r.Response);
+        callback(null, {} as r.Response, null);
       };
       asInternal(serviceObject).request_(reqOpts, () => {
         done();
@@ -714,7 +713,7 @@ describe('ServiceObject', () => {
                 {
                   parent: true,
                 });
-            callback(null, null, {} as r.Response);
+            callback(null, {} as r.Response, null);
           });
 
       const res = await child.request_({uri: ''});
@@ -735,7 +734,7 @@ describe('ServiceObject', () => {
         assert.deepStrictEqual(
             reqOpts.interceptors_, serviceObjectInterceptors);
         assert.notStrictEqual(reqOpts.interceptors_, serviceObjectInterceptors);
-        callback(null, null, {} as r.Response);
+        callback(null, {} as r.Response, null);
         done();
       };
       asInternal(serviceObject).request_({uri: ''}, () => {});
@@ -768,7 +767,7 @@ describe('ServiceObject', () => {
       sandbox.stub(asInternal(serviceObject), 'request_')
           .callsFake((reqOpts, callback) => {
             assert.strictEqual(reqOpts, fakeOptions);
-            callback!(null, null, {} as r.Response);
+            callback!(null, {} as r.Response, null);
           });
       await serviceObject.request(fakeOptions);
     });

--- a/test/service.ts
+++ b/test/service.ts
@@ -16,13 +16,12 @@
 
 import * as assert from 'assert';
 import * as extend from 'extend';
-import {GoogleAuth} from 'google-auth-library';
 import * as proxyquire from 'proxyquire';
-import {Request, RequestResponse} from 'request';
+import {Request, RequestCallback, RequestResponse} from 'request';
 
 import {Interceptor} from '../src';
 import {ServiceConfig, ServiceOptions} from '../src/service';
-import {BodyResponseCallback, DecorateRequestOptions, MakeAuthenticatedRequest, MakeAuthenticatedRequestFactoryConfig, util, Util} from '../src/util';
+import {DecorateRequestOptions, MakeAuthenticatedRequest, MakeAuthenticatedRequestFactoryConfig, util, Util} from '../src/util';
 
 proxyquire.noPreserveCache();
 
@@ -266,12 +265,11 @@ describe('Service', () => {
     it('should compose the correct request', done => {
       const expectedUri = [service.baseUrl, reqOpts.uri].join('/');
       service.makeAuthenticatedRequest =
-          (reqOpts_: DecorateRequestOptions,
-           callback: BodyResponseCallback) => {
+          (reqOpts_: DecorateRequestOptions, callback: RequestCallback) => {
             assert.notStrictEqual(reqOpts_, reqOpts);
             assert.strictEqual(reqOpts_.uri, expectedUri);
             assert.strictEqual(reqOpts.interceptors_, undefined);
-            callback(null);  // done()
+            callback(null, null!, null);  // done()
           };
       service.request_(reqOpts, () => done());
     });


### PR DESCRIPTION
So here I am, trying to figure out what in God's green earth is happening in the compute tests.  I'm looking at an overridden `request` function that assumes a callback like `(err, response, body) => {}`, and I'm all like "what?  this is so weird.  That's not what the TypeScript types say the function signature should be."  Then I sit and think...  but wait, that's the actual order of params from the request module.  What in the hell?

Way back when we (fine, I) converted this module over to TypeScript, I *reversed the order of the request callback parameters*.  The fact that `body` is of type `any`, meant that technically anything was accepted in that parameter.  I feel silly.  I feel bad.  But anyway...  this ought to fix things.