### PR TITLE
fix: allow use of option with setMetadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export {Service, ServiceConfig, ServiceOptions, StreamRequestOptions} from './se
  * @type {module:common/serviceObject}
  * @private
  */
-export {DeleteCallback, ExistsCallback, GetConfig, InstanceResponseCallback, Interceptor, Metadata, MetadataCallback, MetadataResponse, Methods, ResponseCallback, ServiceObject, ServiceObjectConfig, ServiceObjectParent, SetMetadataResponse} from './service-object';
+export {ExistsCallback, GetConfig, InstanceResponseCallback, Interceptor, Metadata, MetadataCallback, MetadataResponse, Methods, ResponseCallback, ServiceObject, ServiceObjectConfig, ServiceObjectParent} from './service-object';
 /**
  * @type {module:common/util}
  * @private

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -101,10 +101,6 @@ export interface CreateCallback<T> {
   (err: ApiError|null, instance?: T|null, ...args: any[]): void;
 }
 
-export interface DeleteCallback {
-  (err: Error|null, apiResponse?: r.Response): void;
-}
-
 export interface GetConfig {
   /**
    * Create the object if it doesn't already exist.
@@ -116,7 +112,6 @@ export interface ResponseCallback {
   (err?: Error|null, apiResponse?: r.Response): void;
 }
 
-export type SetMetadataResponse = [Metadata];
 export type GetResponse<T> = [T, r.Response];
 
 /**
@@ -246,8 +241,8 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {object} callback.apiResponse - The full API response.
    */
   delete(): Promise<[r.Response]>;
-  delete(callback: DeleteCallback): void;
-  delete(callback?: DeleteCallback): Promise<[r.Response]>|void {
+  delete(callback: ResponseCallback): void;
+  delete(callback?: ResponseCallback): Promise<[r.Response]>|void {
     const methodConfig =
         (typeof this.methods.delete === 'object' && this.methods.delete) || {};
     callback = callback || util.noop;
@@ -386,11 +381,16 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {?error} callback.err - An error returned while making this request.
    * @param {object} callback.apiResponse - The full API response.
    */
-  setMetadata(metadata: Metadata): Promise<SetMetadataResponse>;
-  setMetadata(metadata: Metadata, callback: MetadataCallback): void;
-  setMetadata(metadata: Metadata, callback?: MetadataCallback):
-      Promise<SetMetadataResponse>|void {
-    callback = callback || util.noop;
+  setMetadata(metadata: Metadata, options?: {}): Promise<[r.Response]>;
+  setMetadata(metadata: Metadata, options: {}, callback: ResponseCallback):
+      void;
+  setMetadata(metadata: Metadata, callback: ResponseCallback): void;
+  setMetadata(
+      metadata: Metadata, optionsOrCallback?: {}|ResponseCallback,
+      cb?: ResponseCallback): Promise<[r.Response]>|void {
+    const callback = typeof optionsOrCallback === 'function' ?
+        optionsOrCallback :
+        cb || util.noop;
     const methodConfig = (typeof this.methods.setMetadata === 'object' &&
                           this.methods.setMetadata) ||
         {};

--- a/system-test/fixtures/kitchen/src/index.ts
+++ b/system-test/fixtures/kitchen/src/index.ts
@@ -1,5 +1,5 @@
 import {GoogleAuthOptions, Operation,Service, ServiceConfig, ServiceOptions,
-  DeleteCallback, ExistsCallback, GetConfig, MetadataCallback,
+  ExistsCallback, GetConfig, MetadataCallback,
   InstanceResponseCallback, Interceptor, Metadata, Methods, ServiceObject,
   ServiceObjectConfig, StreamRequestOptions, Abortable, AbortableDuplex,
   ApiError, util} from '@google-cloud/common';
@@ -7,4 +7,3 @@ import {GoogleAuthOptions, Operation,Service, ServiceConfig, ServiceOptions,
 util.makeRequest({uri: 'test'}, {}, (err, body, res) => {
   console.log(err);
 });
-

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -576,7 +576,7 @@ describe('ServiceObject', () => {
     it('should execute callback with error & apiResponse', (done) => {
       const error = new Error('Error.');
       sandbox.stub(ServiceObject.prototype, 'request').callsArgWith(1, error);
-      serviceObject.setMetadata({}, (err, apiResponse_) => {
+      serviceObject.setMetadata({}, (err: Error, apiResponse_: r.Response) => {
         assert.strictEqual(err, error);
         assert.strictEqual(apiResponse_, undefined);
         done();
@@ -587,7 +587,7 @@ describe('ServiceObject', () => {
       const apiResponse = {};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsArgWith(1, undefined, apiResponse);
-      serviceObject.setMetadata({}, (err) => {
+      serviceObject.setMetadata({}, (err: Error) => {
         assert.ifError(err);
         assert.strictEqual(serviceObject.metadata, apiResponse);
         done();
@@ -599,7 +599,7 @@ describe('ServiceObject', () => {
       const apiResponse = {body};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsArgWith(1, null, body, apiResponse);
-      serviceObject.setMetadata({}, (err, metadata) => {
+      serviceObject.setMetadata({}, (err: Error, metadata: SO.Metadata) => {
         assert.ifError(err);
         assert.strictEqual(metadata, body);
         done();


### PR DESCRIPTION
This is preventing an upgrade to the latest common in nodejs-storage.