### PR TITLE
chore(deps): update dependency google-auth-library to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "duplexify": "^3.6.0",
     "ent": "^2.2.0",
     "extend": "^3.0.1",
-    "google-auth-library": "^2.0.0",
+    "google-auth-library": "^3.0.0",
     "pify": "^4.0.0",
     "retry-request": "^4.0.0"
   },


### PR DESCRIPTION
This updates google-auth-library to 3.0, which replaced axios with gaxios. More info in the 3.0 release notes: https://github.com/googleapis/google-auth-library-nodejs/releases/tag/v3.0.0