### PR TITLE
feat: allow options to ServiceObject methods

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -20,7 +20,8 @@
 
 import * as pify from 'pify';
 
-import {MetadataCallback, ServiceObject, ServiceObjectConfig} from './service-object';
+import {Metadata, MetadataCallback, ServiceObject, ServiceObjectConfig} from './service-object';
+import {ApiError} from './util';
 
 // tslint:disable-next-line no-any
 export class Operation<T = any> extends ServiceObject<T> {
@@ -122,7 +123,7 @@ export class Operation<T = any> extends ServiceObject<T> {
    * @private
    */
   protected poll_(callback: MetadataCallback): void {
-    this.getMetadata((err, body) => {
+    this.getMetadata((err: ApiError, body: Metadata) => {
       if (err || body!.error) {
         callback(err || body!.error as Error);
         return;

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -115,7 +115,7 @@ export interface GetConfig {
    */
   autoCreate?: boolean;
 }
-type GetOrCreateOptions = GetConfig & CreateOptions;
+type GetOrCreateOptions = GetConfig&CreateOptions;
 export type GetResponse<T> = [T, r.Response];
 
 export interface ResponseCallback {
@@ -254,9 +254,11 @@ class ServiceObject<T = any> extends EventEmitter {
   delete(options?: DeleteOptions): Promise<[r.Response]>;
   delete(options: DeleteOptions, callback: DeleteCallback): void;
   delete(callback: DeleteCallback): void;
-  delete(optionsOrCallback: DeleteOptions|DeleteCallback, cb?: DeleteCallback): Promise<[r.Response]>|void {
-    const [options, callback] = util.maybeOptionsOrCallback<DeleteOptions, DeleteCallback>(
-        optionsOrCallback, cb);
+  delete(optionsOrCallback: DeleteOptions|DeleteCallback, cb?: DeleteCallback):
+      Promise<[r.Response]>|void {
+    const [options, callback] =
+        util.maybeOptionsOrCallback<DeleteOptions, DeleteCallback>(
+            optionsOrCallback, cb);
 
     const methodConfig =
         (typeof this.methods.delete === 'object' && this.methods.delete) || {};
@@ -284,9 +286,11 @@ class ServiceObject<T = any> extends EventEmitter {
   exists(options?: ExistsOptions): Promise<[boolean]>;
   exists(options: ExistsOptions, callback: ExistsCallback): void;
   exists(callback: ExistsCallback): void;
-  exists(optionsOrCallback?: ExistsOptions|ExistsCallback, cb?:ExistsCallback): void|Promise<[boolean]> {
-    const [options, callback] = util.maybeOptionsOrCallback<ExistsOptions, ExistsCallback>(
-      optionsOrCallback, cb);
+  exists(optionsOrCallback?: ExistsOptions|ExistsCallback, cb?: ExistsCallback):
+      void|Promise<[boolean]> {
+    const [options, callback] =
+        util.maybeOptionsOrCallback<ExistsOptions, ExistsCallback>(
+            optionsOrCallback, cb);
 
     this.get(options, err => {
       if (err) {
@@ -313,15 +317,15 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {object} callback.instance - The instance.
    * @param {object} callback.apiResponse - The full API response.
    */
-  get(options?:GetOrCreateOptions): Promise<GetResponse<T>>;
-  get(callback:InstanceResponseCallback<T>): void;
-  get(options:GetOrCreateOptions, callback:InstanceResponseCallback<T>): void;
-  get(optionsOrCallback?:GetOrCreateOptions|InstanceResponseCallback<T>, cb?:InstanceResponseCallback<T>): Promise<GetResponse<T>>|void {
+  get(options?: GetOrCreateOptions): Promise<GetResponse<T>>;
+  get(callback: InstanceResponseCallback<T>): void;
+  get(options: GetOrCreateOptions, callback: InstanceResponseCallback<T>): void;
+  get(optionsOrCallback?: GetOrCreateOptions|InstanceResponseCallback<T>,
+      cb?: InstanceResponseCallback<T>): Promise<GetResponse<T>>|void {
     const self = this;
-    
-    const [options, callback] =
-        util.maybeOptionsOrCallback<GetOrCreateOptions, InstanceResponseCallback<T>>(
-            optionsOrCallback, cb);
+
+    const [options, callback] = util.maybeOptionsOrCallback<
+        GetOrCreateOptions, InstanceResponseCallback<T>>(optionsOrCallback, cb);
 
     const autoCreate = options.autoCreate && typeof this.create === 'function';
     delete options.autoCreate;

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -43,12 +43,12 @@ export interface Interceptor {
 }
 
 // tslint:disable-next-line:no-any
-export type GetMetadataOptions = any;
+export type GetMetadataOptions = object;
 
 // tslint:disable-next-line:no-any
 export type Metadata = any;
 // tslint:disable-next-line:no-any
-export type SetMetadataOptions = any;
+export type SetMetadataOptions = object;
 export type MetadataResponse = [Metadata, r.Response];
 export type MetadataCallback =
     (err: Error|null, metadata?: Metadata, apiResponse?: r.Response) => void;
@@ -365,18 +365,10 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {object} callback.metadata - The metadata for this object.
    * @param {object} callback.apiResponse - The full API response.
    */
-  getMetadata(options?: GetMetadataOptions): Promise<MetadataResponse>;
-  getMetadata(callback: MetadataCallback): void;
-  getMetadata(options: GetMetadataOptions, callback: MetadataCallback): void;
-  getMetadata(
-      optionsOrCallback?: GetMetadataOptions|MetadataCallback,
-      callback?: MetadataCallback): Promise<MetadataResponse>|void {
-    let options: GetMetadataOptions = {};
-    if (typeof optionsOrCallback === 'function') {
-      callback = optionsOrCallback;
-    } else if (optionsOrCallback) {
-      options = optionsOrCallback;
-    }
+  getMetadata(options?:GetMetadataOptions): Promise<MetadataResponse>;
+  getMetadata(callback:MetadataCallback): void;
+  getMetadata(optionsOrCallback:GetMetadataOptions|MetadataCallback, cb?: MetadataCallback):Promise<MetadataResponse>|void {
+    const [options, callback] = util.maybeOptionsOrCallback<GetMetadataOptions, MetadataCallback>(optionsOrCallback, cb);
 
     const methodConfig = (typeof this.methods.getMetadata === 'object' &&
                           this.methods.getMetadata) ||
@@ -407,21 +399,11 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {?error} callback.err - An error returned while making this request.
    * @param {object} callback.apiResponse - The full API response.
    */
-  setMetadata(metadata: Metadata, options?: SetMetadataOptions):
-      Promise<SetMetadataResponse>;
-  setMetadata(
-      metadata: Metadata, options: SetMetadataOptions,
-      callback: MetadataCallback): void;
+  setMetadata(metadata: Metadata, options?: SetMetadataOptions): Promise<SetMetadataResponse>;
   setMetadata(metadata: Metadata, callback: MetadataCallback): void;
-  setMetadata(
-      metadata: Metadata,
-      optionsOrCallback?: SetMetadataOptions|MetadataCallback,
-      callback?: MetadataCallback): Promise<SetMetadataResponse>|void {
-    const options =
-        typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
-    callback =
-        typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
-    callback = callback || util.noop;
+  setMetadata(metadata: Metadata, options: SetMetadataOptions, callback: MetadataCallback): void;
+  setMetadata(metadata: Metadata, optionsOrCallback:SetMetadataOptions|MetadataCallback, cb?: MetadataCallback): Promise<SetMetadataResponse>|void {
+    const [options, callback] = util.maybeOptionsOrCallback<SetMetadataOptions, MetadataCallback>(optionsOrCallback, cb);
     const methodConfig = (typeof this.methods.setMetadata === 'object' &&
                           this.methods.setMetadata) ||
         {};

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -365,10 +365,14 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {object} callback.metadata - The metadata for this object.
    * @param {object} callback.apiResponse - The full API response.
    */
-  getMetadata(options?:GetMetadataOptions): Promise<MetadataResponse>;
-  getMetadata(callback:MetadataCallback): void;
-  getMetadata(optionsOrCallback:GetMetadataOptions|MetadataCallback, cb?: MetadataCallback):Promise<MetadataResponse>|void {
-    const [options, callback] = util.maybeOptionsOrCallback<GetMetadataOptions, MetadataCallback>(optionsOrCallback, cb);
+  getMetadata(options?: GetMetadataOptions): Promise<MetadataResponse>;
+  getMetadata(callback: MetadataCallback): void;
+  getMetadata(
+      optionsOrCallback: GetMetadataOptions|MetadataCallback,
+      cb?: MetadataCallback): Promise<MetadataResponse>|void {
+    const [options, callback] =
+        util.maybeOptionsOrCallback<GetMetadataOptions, MetadataCallback>(
+            optionsOrCallback, cb);
 
     const methodConfig = (typeof this.methods.getMetadata === 'object' &&
                           this.methods.getMetadata) ||
@@ -399,11 +403,19 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {?error} callback.err - An error returned while making this request.
    * @param {object} callback.apiResponse - The full API response.
    */
-  setMetadata(metadata: Metadata, options?: SetMetadataOptions): Promise<SetMetadataResponse>;
+  setMetadata(metadata: Metadata, options?: SetMetadataOptions):
+      Promise<SetMetadataResponse>;
   setMetadata(metadata: Metadata, callback: MetadataCallback): void;
-  setMetadata(metadata: Metadata, options: SetMetadataOptions, callback: MetadataCallback): void;
-  setMetadata(metadata: Metadata, optionsOrCallback:SetMetadataOptions|MetadataCallback, cb?: MetadataCallback): Promise<SetMetadataResponse>|void {
-    const [options, callback] = util.maybeOptionsOrCallback<SetMetadataOptions, MetadataCallback>(optionsOrCallback, cb);
+  setMetadata(
+      metadata: Metadata, options: SetMetadataOptions,
+      callback: MetadataCallback): void;
+  setMetadata(
+      metadata: Metadata,
+      optionsOrCallback: SetMetadataOptions|MetadataCallback,
+      cb?: MetadataCallback): Promise<SetMetadataResponse>|void {
+    const [options, callback] =
+        util.maybeOptionsOrCallback<SetMetadataOptions, MetadataCallback>(
+            optionsOrCallback, cb);
     const methodConfig = (typeof this.methods.setMetadata === 'object' &&
                           this.methods.setMetadata) ||
         {};

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -49,6 +49,7 @@ export type MetadataResponse = [Metadata, r.Response];
 export type MetadataCallback =
     (err: Error|null, metadata?: Metadata, apiResponse?: r.Response) => void;
 
+export type ExistsOptions = object;
 export interface ExistsCallback {
   (err: Error|null, exists?: boolean): void;
 }
@@ -280,10 +281,14 @@ class ServiceObject<T = any> extends EventEmitter {
    * @param {?error} callback.err - An error returned while making this request.
    * @param {boolean} callback.exists - Whether the object exists or not.
    */
-  exists(): Promise<[boolean]>;
+  exists(options?: ExistsOptions): Promise<[boolean]>;
+  exists(options: ExistsOptions, callback: ExistsCallback): void;
   exists(callback: ExistsCallback): void;
-  exists(callback?: ExistsCallback): void|Promise<[boolean]> {
-    this.get(err => {
+  exists(optionsOrCallback?: ExistsOptions|ExistsCallback, cb?:ExistsCallback): void|Promise<[boolean]> {
+    const [options, callback] = util.maybeOptionsOrCallback<ExistsOptions, ExistsCallback>(
+      optionsOrCallback, cb);
+
+    this.get(options, err => {
       if (err) {
         if (err.code === 404) {
           callback!(null, false);

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -306,7 +306,7 @@ class ServiceObject<T = any> extends EventEmitter {
   get(options?:GetOrCreateOptions): Promise<GetResponse<T>>;
   get(callback:InstanceResponseCallback<T>): void;
   get(options:GetOrCreateOptions, callback:InstanceResponseCallback<T>): void;
-  get(optionsOrCallback:GetOrCreateOptions|InstanceResponseCallback<T>, cb?:InstanceResponseCallback<T>): Promise<GetResponse<T>>|void {
+  get(optionsOrCallback?:GetOrCreateOptions|InstanceResponseCallback<T>, cb?:InstanceResponseCallback<T>): Promise<GetResponse<T>>|void {
     const self = this;
     
     const [options, callback] =

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -500,7 +500,7 @@ describe('ServiceObject', () => {
     it('should execute callback with error & apiResponse', (done) => {
       const error = new Error('ಠ_ಠ');
       sandbox.stub(ServiceObject.prototype, 'request').callsArgWith(1, error);
-      serviceObject.getMetadata((err, metadata) => {
+      serviceObject.getMetadata((err: Error, metadata: {}) => {
         assert.strictEqual(err, error);
         assert.strictEqual(metadata, undefined);
         done();
@@ -511,7 +511,7 @@ describe('ServiceObject', () => {
       const apiResponse = {};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsArgWith(1, null, {}, apiResponse);
-      serviceObject.getMetadata(err => {
+      serviceObject.getMetadata((err: Error) => {
         assert.ifError(err);
         assert.deepStrictEqual(serviceObject.metadata, apiResponse);
         done();
@@ -523,7 +523,7 @@ describe('ServiceObject', () => {
       const requestResponse = {body: apiResponse};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsArgWith(1, null, apiResponse, requestResponse);
-      serviceObject.getMetadata((err, metadata) => {
+      serviceObject.getMetadata((err: Error, metadata: {}) => {
         assert.ifError(err);
         assert.strictEqual(metadata, apiResponse);
         done();
@@ -576,7 +576,7 @@ describe('ServiceObject', () => {
     it('should execute callback with error & apiResponse', (done) => {
       const error = new Error('Error.');
       sandbox.stub(ServiceObject.prototype, 'request').callsArgWith(1, error);
-      serviceObject.setMetadata({}, (err, apiResponse_) => {
+      serviceObject.setMetadata({}, (err: Error, apiResponse_: {}) => {
         assert.strictEqual(err, error);
         assert.strictEqual(apiResponse_, undefined);
         done();
@@ -587,7 +587,7 @@ describe('ServiceObject', () => {
       const apiResponse = {};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsArgWith(1, undefined, apiResponse);
-      serviceObject.setMetadata({}, (err) => {
+      serviceObject.setMetadata({}, (err: Error) => {
         assert.ifError(err);
         assert.strictEqual(serviceObject.metadata, apiResponse);
         done();
@@ -599,7 +599,7 @@ describe('ServiceObject', () => {
       const apiResponse = {body};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsArgWith(1, null, body, apiResponse);
-      serviceObject.setMetadata({}, (err, metadata) => {
+      serviceObject.setMetadata({}, (err: Error, metadata: {}) => {
         assert.ifError(err);
         assert.strictEqual(metadata, body);
         done();

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -278,7 +278,7 @@ describe('ServiceObject', () => {
       const error = new Error('🦃');
       sandbox.stub(ServiceObject.prototype, 'request').callsArgWith(1, error);
       const serviceObject = new ServiceObject(CONFIG);
-      serviceObject.delete((err, apiResponse_) => {
+      serviceObject.delete((err: Error, apiResponse_: {}) => {
         assert.strictEqual(err, error);
         assert.strictEqual(apiResponse_, undefined);
         done();
@@ -295,8 +295,8 @@ describe('ServiceObject', () => {
     it('should execute callback with false if 404', (done) => {
       const error = new ApiError('');
       error.code = 404;
-      sandbox.stub(serviceObject, 'get').callsArgWith(0, error);
-      serviceObject.exists((err, exists) => {
+      sandbox.stub(serviceObject, 'get').callsArgWith(1, error);
+      serviceObject.exists((err: Error, exists: boolean) => {
         assert.ifError(err);
         assert.strictEqual(exists, false);
         done();
@@ -306,8 +306,8 @@ describe('ServiceObject', () => {
     it('should execute callback with error if not 404', (done) => {
       const error = new ApiError('');
       error.code = 500;
-      sandbox.stub(serviceObject, 'get').callsArgWith(0, error);
-      serviceObject.exists((err, exists) => {
+      sandbox.stub(serviceObject, 'get').callsArgWith(1, error);
+      serviceObject.exists((err: Error, exists: boolean) => {
         assert.strictEqual(err, error);
         assert.strictEqual(exists, undefined);
         done();
@@ -315,8 +315,8 @@ describe('ServiceObject', () => {
     });
 
     it('should execute callback with true if no error', (done) => {
-      sandbox.stub(serviceObject, 'get').callsArgWith(0, null);
-      serviceObject.exists((err, exists) => {
+      sandbox.stub(serviceObject, 'get').callsArgWith(1, null);
+      serviceObject.exists((err: Error, exists: boolean) => {
         assert.ifError(err);
         assert.strictEqual(exists, true);
         done();
@@ -339,16 +339,17 @@ describe('ServiceObject', () => {
           promisify((_callback: SO.MetadataCallback): void => {
             done();
           });
-      (serviceObject as FakeServiceObject).get(undefined, assert.ifError);
+      (serviceObject as FakeServiceObject).get(assert.ifError);
     });
 
     it('should execute callback with error & metadata', (done) => {
       const error = new Error('Error.');
       const metadata = {} as SO.Metadata;
 
-      serviceObject.getMetadata = promisify((callback: SO.MetadataCallback) => {
-        callback(error, metadata);
-      });
+      serviceObject.getMetadata = promisify(
+          (options: SO.GetMetadataOptions, callback: SO.MetadataCallback) => {
+            callback(error, metadata);
+          });
 
       serviceObject.get((err, instance, metadata_) => {
         assert.strictEqual(err, error);
@@ -362,9 +363,10 @@ describe('ServiceObject', () => {
     it('should execute callback with instance & metadata', (done) => {
       const metadata = {} as SO.Metadata;
 
-      serviceObject.getMetadata = promisify((callback: SO.MetadataCallback) => {
-        callback(null, metadata);
-      });
+      serviceObject.getMetadata = promisify(
+          (options: SO.GetMetadataOptions, callback: SO.MetadataCallback) => {
+            callback(null, metadata);
+          });
 
       serviceObject.get((err, instance, metadata_) => {
         assert.ifError(err);
@@ -388,8 +390,8 @@ describe('ServiceObject', () => {
           autoCreate: true,
         };
 
-        serviceObject.getMetadata =
-            promisify((callback: SO.MetadataCallback) => {
+        serviceObject.getMetadata = promisify(
+            (options: SO.GetMetadataOptions, callback: SO.MetadataCallback) => {
               callback(ERROR, METADATA);
             });
       });


### PR DESCRIPTION
#### To Dos
- [x] Tests

This allows `options` to be passed to several methods on ServiceObject:

- [x] delete
- [x] exists
- [x] get
- [x] getMetadata
- [x] setMetadata

For Storage, in order to support the `userProject` object, we ended up duplicating many of these methods, so that we could pass extra parameters along with the request as query string parameters. With this change, we will just support that here, where it probably belongs.

Sending this in early for feedback before I carry on with the other methods and tests.