### PR TITLE
fix: favor user options over defaults

### DIFF
--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -265,13 +265,11 @@ class ServiceObject<T = any> extends EventEmitter {
     const methodConfig =
         (typeof this.methods.delete === 'object' && this.methods.delete) || {};
 
-    const reqOpts = extend(
-        {
-          method: 'DELETE',
-          uri: '',
-          qs: options,
-        },
-        methodConfig.reqOpts);
+    const reqOpts = extend(true, methodConfig.reqOpts, {
+      method: 'DELETE',
+      uri: '',
+      qs: options,
+    });
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
@@ -384,12 +382,10 @@ class ServiceObject<T = any> extends EventEmitter {
     const methodConfig = (typeof this.methods.getMetadata === 'object' &&
                           this.methods.getMetadata) ||
         {};
-    const reqOpts = extend(
-        {
-          uri: '',
-          qs: options,
-        },
-        methodConfig.reqOpts);
+    const reqOpts = extend(true, methodConfig.reqOpts, {
+      uri: '',
+      qs: options,
+    });
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.
@@ -427,14 +423,12 @@ class ServiceObject<T = any> extends EventEmitter {
                           this.methods.setMetadata) ||
         {};
 
-    const reqOpts = extend(
-        true, {
-          method: 'PATCH',
-          uri: '',
-          json: metadata,
-          qs: options,
-        },
-        methodConfig.reqOpts);
+    const reqOpts = extend(true, methodConfig.reqOpts, {
+      method: 'PATCH',
+      uri: '',
+      json: metadata,
+      qs: options,
+    });
 
     // The `request` method may have been overridden to hold any special
     // behavior. Ensure we call the original `request` method.

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -249,10 +249,10 @@ describe('ServiceObject', () => {
     });
 
     it('should accept options', (done) => {
-      const options = {};
+      const options = {queryOptionProperty: true};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake((reqOpts, callback) => {
-            assert.strictEqual(reqOpts.qs, options);
+            assert.deepStrictEqual(reqOpts.qs, options);
             done();
             callback(null, null, {} as r.Response);
           });
@@ -315,10 +315,10 @@ describe('ServiceObject', () => {
     });
 
     it('should accept options', (done) => {
-      const options = {};
+      const options = {queryOptionProperty: true};
       sandbox.stub(ServiceObject.prototype, 'get')
           .callsFake((options_, callback) => {
-            assert.strictEqual(options_, options);
+            assert.deepStrictEqual(options_, options);
             done();
             callback(null, null, {} as r.Response);
           });
@@ -520,10 +520,10 @@ describe('ServiceObject', () => {
     });
 
     it('should accept options', (done) => {
-      const options = {};
+      const options = {queryOptionProperty: true};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake(function(this: ServiceObject, reqOpts, callback) {
-            assert.strictEqual(reqOpts.qs, options);
+            assert.deepStrictEqual(reqOpts.qs, options);
             done();
             callback(null, null, {} as r.Response);
           });
@@ -595,13 +595,13 @@ describe('ServiceObject', () => {
 
   describe('setMetadata', () => {
     it('should make the correct request', (done) => {
-      const metadata = {};
+      const metadata = {metadataProperty: true};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake(function(this: ServiceObject, reqOpts, callback) {
             assert.strictEqual(this, serviceObject);
             assert.strictEqual(reqOpts.method, 'PATCH');
             assert.strictEqual(reqOpts.uri, '');
-            assert.strictEqual(reqOpts.json, metadata);
+            assert.deepStrictEqual(reqOpts.json, metadata);
             done();
             callback(null, null, {} as r.Response);
           });
@@ -610,10 +610,10 @@ describe('ServiceObject', () => {
 
     it('should accept options', (done) => {
       const metadata = {};
-      const options = {};
+      const options = {queryOptionProperty: true};
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake(function(this: ServiceObject, reqOpts, callback) {
-            assert.strictEqual(reqOpts.qs, options);
+            assert.deepStrictEqual(reqOpts.qs, options);
             done();
             callback(null, null, {} as r.Response);
           });

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -259,27 +259,33 @@ describe('ServiceObject', () => {
       serviceObject.delete(options, assert.ifError);
     });
 
-    it('should extend the request options with defaults', (done) => {
-      const method = {
+    it('should extend the defaults with request options', (done) => {
+      const methodConfig = {
         reqOpts: {
-          method: 'override',
           qs: {
-            custom: true,
+            defaultProperty: true,
+            thisPropertyWasOverridden: false,
           },
         },
       };
 
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake((reqOpts_, callback) => {
-            assert.strictEqual(reqOpts_.method, method.reqOpts.method);
-            assert.deepStrictEqual(reqOpts_.qs, method.reqOpts.qs);
+            assert.deepStrictEqual(reqOpts_.qs, {
+              defaultProperty: true,
+              optionalProperty: true,
+              thisPropertyWasOverridden: true,
+            });
             done();
             callback(null, null, null!);
           });
 
       const serviceObject = new ServiceObject(CONFIG) as FakeServiceObject;
-      serviceObject.methods.delete = method;
-      serviceObject.delete();
+      serviceObject.methods.delete = methodConfig;
+      serviceObject.delete({
+        optionalProperty: true,
+        thisPropertyWasOverridden: true,
+      });
     });
 
     it('should not require a callback', () => {
@@ -524,27 +530,33 @@ describe('ServiceObject', () => {
       serviceObject.getMetadata(options, assert.ifError);
     });
 
-    it('should extend the request options with defaults', (done) => {
-      const method = {
+    it('should extend the defaults with request options', (done) => {
+      const methodConfig = {
         reqOpts: {
-          method: 'override',
           qs: {
-            custom: true,
+            defaultProperty: true,
+            thisPropertyWasOverridden: false,
           },
         },
       };
 
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake((reqOpts_, callback) => {
-            assert.strictEqual(reqOpts_.method, method.reqOpts.method);
-            assert.deepStrictEqual(reqOpts_.qs, method.reqOpts.qs);
+            assert.deepStrictEqual(reqOpts_.qs, {
+              defaultProperty: true,
+              optionalProperty: true,
+              thisPropertyWasOverridden: true,
+            });
             done();
-            callback(null, undefined, {} as r.Response);
+            callback(null, null, null!);
           });
 
       const serviceObject = new ServiceObject(CONFIG) as FakeServiceObject;
-      serviceObject.methods.getMetadata = method;
-      serviceObject.getMetadata(() => {});
+      serviceObject.methods.getMetadata = methodConfig;
+      serviceObject.getMetadata({
+        optionalProperty: true,
+        thisPropertyWasOverridden: true,
+      });
     });
 
     it('should execute callback with error & apiResponse', (done) => {
@@ -608,31 +620,33 @@ describe('ServiceObject', () => {
       serviceObject.setMetadata(metadata, options, () => {});
     });
 
-    it('should extend the request options with defaults', (done) => {
-      const metadataDefault = {a: 'b'};
-      const metadata = {c: 'd'};
-      const method = {
+    it('should extend the defaults with request options', (done) => {
+      const methodConfig = {
         reqOpts: {
-          method: 'override',
           qs: {
-            custom: true,
+            defaultProperty: true,
+            thisPropertyWasOverridden: false,
           },
-          json: metadataDefault,
         },
       };
 
-      const expectedJson = extend(true, {}, metadataDefault, metadata);
-      const serviceObject = new ServiceObject(CONFIG);
-      asInternal(serviceObject).methods.setMetadata = method;
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake((reqOpts_, callback) => {
-            assert.deepStrictEqual(reqOpts_.method, method.reqOpts.method);
-            assert.deepStrictEqual(reqOpts_.qs, method.reqOpts.qs);
-            assert.deepStrictEqual(reqOpts_.json, expectedJson);
+            assert.deepStrictEqual(reqOpts_.qs, {
+              defaultProperty: true,
+              optionalProperty: true,
+              thisPropertyWasOverridden: true,
+            });
             done();
             callback(null, null, null!);
           });
-      serviceObject.setMetadata(metadata);
+
+      const serviceObject = new ServiceObject(CONFIG) as FakeServiceObject;
+      serviceObject.methods.setMetadata = methodConfig;
+      serviceObject.setMetadata({}, {
+        optionalProperty: true,
+        thisPropertyWasOverridden: true,
+      });
     });
 
     it('should execute callback with error & apiResponse', (done) => {


### PR DESCRIPTION
When you instantiate a ServiceObject, you can provide some default request configuration options that will be sent along with every API request. This is popular in Storage, where, for example, if the user passes a "generation" for a File object, we put it in the query string parameters that go out with every HTTP request.

We just landed new behavior in this library where the ServiceObject methods, like `get()`, `getMetadata()`, etc. allow an options object. That object is treated as the query string parameters for that request.

And now, we have a new problem I didn't notice until now! Okay, two:

1) we need to deeply extend the default request options with the new, user request options, and
2) the options set at the time of the method call should take precedence over the default ones we set in the constructor.

This changes that, and adds the appropriate tests. Hope this made sense!