### PR TITLE
fix: clone default request configuration object

### DIFF
--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -265,7 +265,7 @@ class ServiceObject<T = any> extends EventEmitter {
     const methodConfig =
         (typeof this.methods.delete === 'object' && this.methods.delete) || {};
 
-    const reqOpts = extend(true, methodConfig.reqOpts, {
+    const reqOpts = extend(true, {}, methodConfig.reqOpts, {
       method: 'DELETE',
       uri: '',
       qs: options,
@@ -382,7 +382,7 @@ class ServiceObject<T = any> extends EventEmitter {
     const methodConfig = (typeof this.methods.getMetadata === 'object' &&
                           this.methods.getMetadata) ||
         {};
-    const reqOpts = extend(true, methodConfig.reqOpts, {
+    const reqOpts = extend(true, {}, methodConfig.reqOpts, {
       uri: '',
       qs: options,
     });
@@ -423,7 +423,7 @@ class ServiceObject<T = any> extends EventEmitter {
                           this.methods.setMetadata) ||
         {};
 
-    const reqOpts = extend(true, methodConfig.reqOpts, {
+    const reqOpts = extend(true, {}, methodConfig.reqOpts, {
       method: 'PATCH',
       uri: '',
       json: metadata,

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -269,8 +269,12 @@ describe('ServiceObject', () => {
         },
       };
 
+      const cachedMethodConfig = extend(true, {}, methodConfig);
+
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake((reqOpts_, callback) => {
+            assert.deepStrictEqual(
+                serviceObject.methods.delete, cachedMethodConfig);
             assert.deepStrictEqual(reqOpts_.qs, {
               defaultProperty: true,
               optionalProperty: true,
@@ -540,8 +544,12 @@ describe('ServiceObject', () => {
         },
       };
 
+      const cachedMethodConfig = extend(true, {}, methodConfig);
+
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake((reqOpts_, callback) => {
+            assert.deepStrictEqual(
+                serviceObject.methods.getMetadata, cachedMethodConfig);
             assert.deepStrictEqual(reqOpts_.qs, {
               defaultProperty: true,
               optionalProperty: true,
@@ -629,9 +637,12 @@ describe('ServiceObject', () => {
           },
         },
       };
+      const cachedMethodConfig = extend(true, {}, methodConfig);
 
       sandbox.stub(ServiceObject.prototype, 'request')
           .callsFake((reqOpts_, callback) => {
+            assert.deepStrictEqual(
+                serviceObject.methods.setMetadata, cachedMethodConfig);
             assert.deepStrictEqual(reqOpts_.qs, {
               defaultProperty: true,
               optionalProperty: true,


### PR DESCRIPTION
Need to clone the default request configuration object. ☺️