### PR TITLE
refactor: remove configurable request

### DIFF
--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -32,7 +32,6 @@ export type RequestResponse = [Metadata, r.Response];
 export interface ServiceObjectParent {
   // tslint:disable-next-line:variable-name
   Promise?: PromiseConstructor;
-  requestModule?: typeof r;
   requestStream(reqOpts: DecorateRequestOptions): r.Request;
   request(reqOpts: DecorateRequestOptions, callback: BodyResponseCallback):
       void;
@@ -82,11 +81,6 @@ export interface ServiceObjectConfig {
    * object is Bucket.
    */
   parent: ServiceObjectParent;
-
-  /**
-   * Dependency for HTTP calls.
-   */
-  requestModule?: typeof r;
 }
 
 export interface Methods {
@@ -148,7 +142,6 @@ class ServiceObject<T = any> extends EventEmitter {
   protected interceptors: Interceptor[];
   // tslint:disable-next-line:variable-name
   Promise?: PromiseConstructor;
-  requestModule: typeof r;
 
   /*
    * @constructor
@@ -178,8 +171,6 @@ class ServiceObject<T = any> extends EventEmitter {
     this.methods = config.methods || {};
     this.interceptors = [];
     this.Promise = this.parent ? this.parent.Promise : undefined;
-    this.requestModule =
-        (config.requestModule || (this.parent && this.parent.requestModule))!;
 
     if (config.methods) {
       Object.getOwnPropertyNames(ServiceObject.prototype)

--- a/src/service.ts
+++ b/src/service.ts
@@ -45,7 +45,6 @@ export interface ServiceConfig {
 
   projectIdRequired?: boolean;
   packageJson: PackageJson;
-  requestModule: typeof r;
 
   /**
    * Reuse an existing GoogleAuth client instead of creating a new one.
@@ -72,7 +71,6 @@ export class Service {
   makeAuthenticatedRequest: MakeAuthenticatedRequest;
   authClient: GoogleAuth;
   private getCredentials: {};
-  requestModule: typeof r;
 
   /**
    * Service is a base class, meant to be inherited from by a "service," like
@@ -99,7 +97,6 @@ export class Service {
     this.projectId = options.projectId || PROJECT_ID_TOKEN;
     this.projectIdRequired = config.projectIdRequired !== false;
     this.Promise = options.promise || Promise;
-    this.requestModule = config.requestModule;
 
     const reqCfg = extend({}, config, {
       projectIdRequired: this.projectIdRequired,
@@ -107,8 +104,7 @@ export class Service {
       credentials: options.credentials,
       keyFile: options.keyFilename,
       email: options.email,
-      token: options.token,
-      request: this.requestModule,
+      token: options.token
     });
 
     this.makeAuthenticatedRequest =

--- a/test/operation.ts
+++ b/test/operation.ts
@@ -32,11 +32,7 @@ describe('Operation', () => {
   const sandbox = sinon.createSandbox();
   let operation: Operation;
   beforeEach(() => {
-    operation = new Operation({
-      parent: FAKE_SERVICE,
-      id: OPERATION_ID,
-      requestModule: {} as typeof r,
-    });
+    operation = new Operation({parent: FAKE_SERVICE, id: OPERATION_ID});
     operation.Promise = Promise;
   });
 
@@ -45,7 +41,7 @@ describe('Operation', () => {
   });
 
   describe('instantiation', () => {
-    const parent = {requestModule: {}};
+    const parent = {};
 
     it('should extend ServiceObject and EventEmitter', () => {
       const svcObj = ServiceObject;

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -44,9 +44,7 @@ describe('ServiceObject', () => {
 
   const CONFIG = {
     baseUrl: 'base-url',
-    parent: {
-      requestModule: {},
-    } as Service,
+    parent: {} as Service,
     id: 'id',
     createMethod: util.noop
   };
@@ -115,16 +113,10 @@ describe('ServiceObject', () => {
       // tslint:disable-next-line:variable-name
       const FakePromise = () => {};
       const config = extend({}, CONFIG, {
-        parent: {Promise: FakePromise, requestModule: {}},
+        parent: {Promise: FakePromise},
       });
       const serviceObject = new ServiceObject(config) as FakeServiceObject;
       assert.strictEqual(serviceObject.Promise, FakePromise);
-    });
-
-    it('should inherit the parents requestModule', () => {
-      const serviceObject = new ServiceObject(CONFIG);
-      assert.strictEqual(
-          serviceObject.requestModule, CONFIG.parent.requestModule);
     });
   });
 


### PR DESCRIPTION
**BREAKING CHANGE**: This PR removes the ability to configure a custom implementation of the `Request` module. This was necessary when we were migrating from `request` to `teeny-request`, but that migration is now complete.  All interfaces at accepted a custom implementation of `request` will no longer accept one. `teeny-request` is now just included in the box.

This change is being made to simplify the `request` interface touch points.