### PR TITLE
fix: @types/node@11.13.0 breaks paginate/promisifyAll

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",
     "@types/nock": "^9.3.1",
-    "@types/node": "^10.3.1",
+    "@types/node": "11.12.4",
     "@types/pify": "^3.0.2",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.10",


### PR DESCRIPTION
see: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34414 the release of `@types/node@11.13.0` breaks EventEmitter, such that it is no longer coerced as a `Function`.

This is a temporary fix to address https://github.com/googleapis/nodejs-storage/pull/649, https://github.com/googleapis/nodejs-storage/pull/655, etc., until we get feedback from DefinitelyTypes.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
