### PR TITLE
chore: unpin @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",
     "@types/nock": "^9.3.1",
-    "@types/node": "11.12.4",
+    "@types/node": "^11.13.0",
     "@types/pify": "^3.0.2",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.10",


### PR DESCRIPTION
Since we have figured out the root cause of https://github.com/googleapis/nodejs-common/pull/397, I think it should be ok to unpin these types.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
