### PR TITLE
fix: teeny-request should be dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "extend": "^3.0.2",
     "google-auth-library": "^3.1.1",
     "pify": "^4.0.1",
-    "retry-request": "^4.0.0"
+    "retry-request": "^4.0.0",
+    "teeny-request": "^3.11.3"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.9",
@@ -74,7 +75,6 @@
     "proxyquire": "^2.1.0",
     "sinon": "^7.3.0",
     "source-map-support": "^0.5.11",
-    "teeny-request": "^3.11.3",
     "tmp": "0.1.0",
     "typescript": "~3.4.0"
   }


### PR DESCRIPTION
Fixes issues seen here: https://github.com/googleapis/cloud-debug-nodejs/pull/667

teeny-request is required in util.js, but is only currently present as a dev-dependency.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
