### PR TITLE
feat!: add apiEndpoint property to service config

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -45,6 +45,12 @@ export interface ServiceConfig {
   baseUrl: string;
 
   /**
+   * The API Endpoint to use when connecting to the service.
+   * Example:  storage.googleapis.com
+   */
+  apiEndpoint: string;
+
+  /**
    * The scopes required for the request.
    */
   scopes: string[];
@@ -77,6 +83,7 @@ export class Service {
   makeAuthenticatedRequest: MakeAuthenticatedRequest;
   authClient: GoogleAuth;
   private getCredentials: {};
+  readonly apiEndpoint: string;
 
   /**
    * Service is a base class, meant to be inherited from by a "service," like
@@ -97,6 +104,7 @@ export class Service {
     options = options || {};
 
     this.baseUrl = config.baseUrl;
+    this.apiEndpoint = config.apiEndpoint;
     this.globalInterceptors = arrify(options.interceptors_!);
     this.interceptors = [];
     this.packageJson = config.packageJson;

--- a/test/service.ts
+++ b/test/service.ts
@@ -16,7 +16,6 @@
 
 import * as assert from 'assert';
 import * as extend from 'extend';
-import {GoogleAuth} from 'google-auth-library';
 import * as proxyquire from 'proxyquire';
 import {Request, RequestResponse} from 'request';
 
@@ -63,6 +62,7 @@ describe('Service', () => {
     scopes: [],
     baseUrl: 'base-url',
     projectIdRequired: false,
+    apiEndpoint: 'common.endpoint.local',
     packageJson: {
       name: '@google-cloud/service',
       version: '0.2.0',
@@ -137,6 +137,10 @@ describe('Service', () => {
 
     it('should localize the baseUrl', () => {
       assert.strictEqual(service.baseUrl, CONFIG.baseUrl);
+    });
+
+    it('should localize the apiEndpoint', () => {
+      assert.strictEqual(service.apiEndpoint, CONFIG.apiEndpoint);
     });
 
     it('should localize the getCredentials method', () => {


### PR DESCRIPTION
BREAKING CHANGE: This adds the `apiEndpoint` property as a required field for the `ServiceConfig`, and makes it a public property on the `Service` class.  This is being added to broadly support `apiEndpoint` overrides.

See https://github.com/googleapis/nodejs-bigquery/pull/455 to see how this would be used. 