### PR TITLE
chore(deps): update HTTP transport library, teeny-request

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "extend": "^3.0.2",
     "google-auth-library": "^4.0.0",
     "retry-request": "^4.0.0",
-    "teeny-request": "^3.11.3"
+    "teeny-request": "^4.0.0"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.9",

--- a/src/service.ts
+++ b/src/service.ts
@@ -227,9 +227,7 @@ export class Service {
     const pkg = this.packageJson;
     reqOpts.headers = extend({}, reqOpts.headers, {
       'User-Agent': util.getUserAgentFromPackageJson(pkg),
-      'x-goog-api-client': `gl-node/${process.versions.node} gccl/${
-        pkg.version
-      }`,
+      'x-goog-api-client': `gl-node/${process.versions.node} gccl/${pkg.version}`,
     });
 
     if (reqOpts.shouldReturnStream) {


### PR DESCRIPTION
Previously, some API request failures were mistakenly being retried. For more information, please see fhinkel/teeny-request#39