### PR TITLE
Includes the response in the error message when the response body can't be parsed as JSON.

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -367,6 +367,10 @@ export class Util {
       parsedResp.resp.body = parsedResp.body;
     }
 
+    if (parsedResp.err && resp) {
+      parsedResp.err.response = resp;
+    }
+
     callback(parsedResp.err, parsedResp.body, parsedResp.resp);
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -300,7 +300,7 @@ export class PartialFailureError extends Error {
 }
 
 export interface BodyResponseCallback {
-  (err: Error | null, body?: ResponseBody, res?: r.Response): void;
+  (err: Error | ApiError | null, body?: ResponseBody, res?: r.Response): void;
 }
 
 export interface MakeRequestConfig {

--- a/src/util.ts
+++ b/src/util.ts
@@ -404,7 +404,7 @@ export class Util {
    * @param {?error} parsedHttpRespMessage.err - An error detected.
    * @param {object} parsedHttpRespMessage.body - The original body value provided
    *     will try to be JSON.parse'd. If it's successful, the parsed value will
-   * be returned here, otherwise the original value.
+   * be returned here, otherwise the original value and an error will be returned.
    */
   parseHttpRespBody(body: ResponseBody) {
     const parsedHttpRespBody: ParsedHttpResponseBody = {
@@ -415,7 +415,9 @@ export class Util {
       try {
         parsedHttpRespBody.body = JSON.parse(body);
       } catch (err) {
-        parsedHttpRespBody.err = new ApiError('Cannot parse JSON response');
+        parsedHttpRespBody.err = new ApiError(
+          `Cannot parse response as JSON: ${body}`
+        );
       }
     }
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -377,6 +377,20 @@ describe('common/util', () => {
       stub('parseHttpRespBody', () => done()); // Will throw.
       util.handleResp(null, null, null, done);
     });
+
+    it('should surface the response body in the error message when it cannot be JSON-parsed', done => {
+      const unparseableBody = '<html>There was some error</html>';
+
+      util.handleResp(null, null, unparseableBody, err => {
+        if (err === null) {
+          assert.fail('there should be an error');
+        } else {
+          assert.ok(err.message.includes(unparseableBody));
+        }
+
+        done();
+      });
+    });
   });
 
   describe('parseHttpRespMessage', () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -391,6 +391,31 @@ describe('common/util', () => {
         done();
       });
     });
+
+    it('should surface the response body as an error property when it cannot be JSON-parsed', done => {
+      const unparseableBody = '<html>There was some error</html>';
+
+      util.handleResp(
+        null,
+        {body: unparseableBody} as r.Response,
+        unparseableBody,
+        err => {
+          if (err === null) {
+            assert.fail('there should be an error');
+          } else {
+            const response = (err! as ApiError).response;
+
+            if (!response) {
+              assert.fail('there should be a response property on the error');
+            } else {
+              assert.strictEqual(response.body, unparseableBody);
+            }
+          }
+
+          done();
+        }
+      );
+    });
   });
 
   describe('parseHttpRespMessage', () => {


### PR DESCRIPTION
Fixes #446.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)

before:

File               |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------|----------|----------|----------|----------|-------------------|
All files          |    99.24 |    97.86 |      100 |    99.23 |                   |
 index.ts          |      100 |      100 |      100 |      100 |                   |
 operation.ts      |      100 |      100 |      100 |      100 |                   |
 service-object.ts |      100 |    97.92 |      100 |      100 |               184 |
 service.ts        |    98.15 |    95.24 |      100 |    98.11 |               232 |
 util.ts           |    98.97 |     97.9 |      100 |    98.96 |           367,418 |

after:

File               |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------|----------|----------|----------|----------|-------------------|
All files          |    99.49 |    97.86 |      100 |    99.49 |                   |
 index.ts          |      100 |      100 |      100 |      100 |                   |
 operation.ts      |      100 |      100 |      100 |      100 |                   |
 service-object.ts |      100 |    97.92 |      100 |      100 |               184 |
 service.ts        |    98.15 |    95.24 |      100 |    98.11 |               232 |
 util.ts           |    99.49 |     97.9 |      100 |    99.48 |               367 |

- [x] Appropriate docs were updated (if necessary)
  - I didn't see any that were relevant, but I might have missed them
