### PR TITLE
feat: add timeout to options and use it in the reqOpts

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -69,6 +69,7 @@ export interface ServiceOptions extends GoogleAuthOptions {
   promise?: PromiseConstructor;
   email?: string;
   token?: string;
+  timeout?: number; // http.request.options.timeout
 }
 
 export class Service {
@@ -84,6 +85,7 @@ export class Service {
   authClient: GoogleAuth;
   private getCredentials: {};
   readonly apiEndpoint: string;
+  timeout: number;
 
   /**
    * Service is a base class, meant to be inherited from by a "service," like
@@ -103,6 +105,7 @@ export class Service {
   constructor(config: ServiceConfig, options: ServiceOptions = {}) {
     this.baseUrl = config.baseUrl;
     this.apiEndpoint = config.apiEndpoint;
+    this.timeout = options.timeout!;
     this.globalInterceptors = arrify(options.interceptors_!);
     this.interceptors = [];
     this.packageJson = config.packageJson;
@@ -179,7 +182,7 @@ export class Service {
     reqOpts: DecorateRequestOptions | StreamRequestOptions,
     callback?: BodyResponseCallback
   ): void | r.Request {
-    reqOpts = extend(true, {}, reqOpts);
+    reqOpts = extend(true, {}, reqOpts, {timeout: this.timeout});
     const isAbsoluteUrl = reqOpts.uri.indexOf('http') === 0;
     const uriComponents = [this.baseUrl];
 

--- a/test/service.ts
+++ b/test/service.ts
@@ -143,6 +143,17 @@ describe('Service', () => {
       assert.strictEqual(service.apiEndpoint, CONFIG.apiEndpoint);
     });
 
+    it('should default the timeout to undefined', () => {
+      assert.strictEqual(service.timeout, undefined);
+    });
+
+    it('should localize the timeout', () => {
+      const timeout = 10000;
+      const options = extend({}, OPTIONS, {timeout});
+      const service = new Service(fakeCfg, options);
+      assert.strictEqual(service.timeout, timeout);
+    });
+
     it('should localize the getCredentials method', () => {
       function getCredentials() {}
 
@@ -329,6 +340,27 @@ describe('Service', () => {
       const expectedUri = service.baseUrl + reqOpts.uri;
       service.makeAuthenticatedRequest = (reqOpts_: DecorateRequestOptions) => {
         assert.strictEqual(reqOpts_.uri, expectedUri);
+        done();
+      };
+      service.request_(reqOpts, assert.ifError);
+    });
+
+    it('should not set timeout', done => {
+      service.makeAuthenticatedRequest = (reqOpts_: DecorateRequestOptions) => {
+        assert.strictEqual(reqOpts_.timeout, undefined);
+        done();
+      };
+      service.request_(reqOpts, assert.ifError);
+    });
+
+    it('should set reqOpt.timeout', done => {
+      const timeout = 10000;
+      const config = extend({}, CONFIG);
+      const options = extend({}, OPTIONS, {timeout});
+      const service = new Service(config, options);
+
+      service.makeAuthenticatedRequest = (reqOpts_: DecorateRequestOptions) => {
+        assert.strictEqual(reqOpts_.timeout, timeout);
         done();
       };
       service.request_(reqOpts, assert.ifError);


### PR DESCRIPTION
add `timeout` to `service` and pass it to reqOpts.
With this `timeout` can be exposed to users in the child dependencies (storage, bigquery...)
Will apply to googleapis/nodejs-storage/issues/733

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
