### PR TITLE
fix: capture message in ApiError.stack

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -236,6 +236,7 @@ export class ApiError extends Error {
     }
 
     this.message = ApiError.createMultiErrorMessage(errorBody, this.errors);
+    Error.captureStackTrace(this);
   }
   /**
    * Pieces together an error message by combining all unique error messages

--- a/test/util.ts
+++ b/test/util.ts
@@ -146,6 +146,16 @@ describe('common/util', () => {
       assert.strictEqual(apiError.message, expectedMessage);
     });
 
+    it('should use message in stack', () => {
+      const expectedMessage = 'Message is in the stack too!';
+      const apiError = new ApiError(expectedMessage);
+
+      assert.strictEqual(
+        (apiError.stack || '').split('\n')[0],
+        `Error: ${expectedMessage}`
+      );
+    });
+
     it('should build correct ApiError', () => {
       const fakeMessage = 'Formatted Error.';
       const fakeResponse = {statusCode: 200} as r.Response;


### PR DESCRIPTION
Fixes #465

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

#### Note:
- automated tests may fail because of https://github.com/googleapis/teeny-request/pull/66