### PR TITLE
refactor: correct internal timeout field type

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -85,7 +85,7 @@ export class Service {
   authClient: GoogleAuth;
   private getCredentials: {};
   readonly apiEndpoint: string;
-  timeout: number;
+  timeout?: number;
 
   /**
    * Service is a base class, meant to be inherited from by a "service," like
@@ -105,7 +105,7 @@ export class Service {
   constructor(config: ServiceConfig, options: ServiceOptions = {}) {
     this.baseUrl = config.baseUrl;
     this.apiEndpoint = config.apiEndpoint;
-    this.timeout = options.timeout!;
+    this.timeout = options.timeout;
     this.globalInterceptors = arrify(options.interceptors_!);
     this.interceptors = [];
     this.packageJson = config.packageJson;


### PR DESCRIPTION
`timeout` isn't necessarily (and doesn't need to be) defined, so this change removes the type coercion. This is a TS change on an internal field only.
