### PR TITLE
feat: return more helpful error when authentication fails

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -600,6 +600,7 @@ export class Util {
         err: Error | null,
         authenticatedReqOpts?: DecorateRequestOptions
       ) => {
+        const authLibraryError = err;
         const autoAuthFailed =
           err &&
           err.message.indexOf('Could not load the default credentials') > -1;
@@ -651,7 +652,18 @@ export class Util {
           activeRequest_ = util.makeRequest(
             authenticatedReqOpts!,
             reqConfig,
-            callback!
+            // tslint:disable-next-line:only-arrow-functions
+            function(apiResponseError) {
+              if (
+                apiResponseError &&
+                (apiResponseError as ApiError).code === 401
+              ) {
+                // Re-use the "Could not load the default credentials error" if
+                // the API request failed due to missing credentials.
+                apiResponseError = authLibraryError;
+              }
+              callback!(apiResponseError, arguments[1], arguments[2]);
+            }
           );
         }
       };

--- a/src/util.ts
+++ b/src/util.ts
@@ -652,8 +652,7 @@ export class Util {
           activeRequest_ = util.makeRequest(
             authenticatedReqOpts!,
             reqConfig,
-            // tslint:disable-next-line:only-arrow-functions
-            function(apiResponseError) {
+            (apiResponseError, ...params) => {
               if (
                 apiResponseError &&
                 (apiResponseError as ApiError).code === 401
@@ -662,7 +661,7 @@ export class Util {
                 // the API request failed due to missing credentials.
                 apiResponseError = authLibraryError;
               }
-              callback!(apiResponseError, arguments[1], arguments[2]);
+              callback!(apiResponseError, ...params);
             }
           );
         }

--- a/test/util.ts
+++ b/test/util.ts
@@ -925,6 +925,37 @@ describe('common/util', () => {
           });
         });
 
+        it('should block 401 API errors', done => {
+          const authClientError = new Error(
+            'Could not load the default credentials'
+          );
+          authClient.authorizeRequest = async () => {
+            throw authClientError;
+          };
+          sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
+
+          const makeRequestArg1 = new Error('API 401 Error.') as ApiError;
+          makeRequestArg1.code = 401;
+          const makeRequestArg2 = {};
+          const makeRequestArg3 = {};
+          stub('makeRequest', (authenticatedReqOpts, cfg, callback) => {
+            callback(makeRequestArg1, makeRequestArg2, makeRequestArg3);
+          });
+
+          const makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(
+            {}
+          );
+          makeAuthenticatedRequest(
+            {} as DecorateRequestOptions,
+            (arg1, arg2, arg3) => {
+              assert.strictEqual(arg1, authClientError);
+              assert.strictEqual(arg2, makeRequestArg2);
+              assert.strictEqual(arg3, makeRequestArg3);
+              done();
+            }
+          );
+        });
+
         it('should block decorateRequest error', done => {
           const decorateRequestError = new Error('Error.');
           sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-auth-library-nodejs/issues/620

Not all API endpoints require authentication, so even when the auth library can't figure out how to generate an API token, we still want to send the API request without one. It might be totally fine.

Or, it might not be, and the API actually requires a token. Fine, then. It returns a 401 with *that API's version of a helpful error.* But, turns out, the auth library has a pretty good version of a helpful error that we'd rather use.