### PR TITLE
fix: do not block API 401 errors when auth was provided

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -655,7 +655,8 @@ export class Util {
             (apiResponseError, ...params) => {
               if (
                 apiResponseError &&
-                (apiResponseError as ApiError).code === 401
+                (apiResponseError as ApiError).code === 401 &&
+                authLibraryError
               ) {
                 // Re-use the "Could not load the default credentials error" if
                 // the API request failed due to missing credentials.

--- a/test/util.ts
+++ b/test/util.ts
@@ -956,6 +956,32 @@ describe('common/util', () => {
           );
         });
 
+        it('should not block 401 errors if auth client succeeds', done => {
+          authClient.authorizeRequest = async (rOpts: {}) => {};
+          sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
+
+          const makeRequestArg1 = new Error('API 401 Error.') as ApiError;
+          makeRequestArg1.code = 401;
+          const makeRequestArg2 = {};
+          const makeRequestArg3 = {};
+          stub('makeRequest', (authenticatedReqOpts, cfg, callback) => {
+            callback(makeRequestArg1, makeRequestArg2, makeRequestArg3);
+          });
+
+          const makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(
+            {}
+          );
+          makeAuthenticatedRequest(
+            {} as DecorateRequestOptions,
+            (arg1, arg2, arg3) => {
+              assert.strictEqual(arg1, makeRequestArg1);
+              assert.strictEqual(arg2, makeRequestArg2);
+              assert.strictEqual(arg3, makeRequestArg3);
+              done();
+            }
+          );
+        });
+
         it('should block decorateRequest error', done => {
           const decorateRequestError = new Error('Error.');
           sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/851