### PR TITLE
feat: if we see EAI_AGAIN error for reason, retry request

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -525,6 +525,9 @@ export class Util {
           if (reason === 'userRateLimitExceeded') {
             return true;
           }
+          if (reason && reason.includes('EAI_AGAIN')) {
+            return true;
+          }
         }
       }
     }

--- a/test/util.ts
+++ b/test/util.ts
@@ -1175,6 +1175,14 @@ describe('common/util', () => {
       rateLimitError.errors = [{reason: 'userRateLimitExceeded'}];
       assert.strictEqual(util.shouldRetryRequest(rateLimitError), true);
     });
+
+    it('should retry on EAI_AGAIN error code', () => {
+      const eaiAgainError = new ApiError('EAI_AGAIN');
+      eaiAgainError.errors = [
+        {reason: 'getaddrinfo EAI_AGAIN pubsub.googleapis.com'},
+      ];
+      assert.strictEqual(util.shouldRetryRequest(eaiAgainError), true);
+    });
   });
 
   describe('makeRequest', () => {


### PR DESCRIPTION
It seems reasonable to retry if we observe an `EAI_AGAIN` as a `reason` for an error.

fixes: #473

---

@vieira if this was in fact the cause of #473, I believe this should address it.
