### PR TITLE
fix!: remove support for custom promises

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -82,16 +82,14 @@ export class Operation<T = any> extends ServiceObject<T> {
   /**
    * Wraps the `complete` and `error` events in a Promise.
    *
-   * @return {promise}
+   * @return {Promise}
    */
   promise() {
-    return new this.Promise!(
-      (resolve: Function, reject: (err: Error) => void) => {
-        this.on('error', reject).on('complete', (metadata: {}) => {
-          resolve([metadata]);
-        });
-      }
-    );
+    return new Promise((resolve, reject) => {
+      this.on('error', reject).on('complete', (metadata: {}) => {
+        resolve([metadata]);
+      });
+    });
   }
 
   /**

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -36,8 +36,6 @@ import {
 export type RequestResponse = [Metadata, r.Response];
 
 export interface ServiceObjectParent {
-  // tslint:disable-next-line:variable-name
-  Promise?: PromiseConstructor;
   requestStream(reqOpts: DecorateRequestOptions): r.Request;
   request(
     reqOpts: DecorateRequestOptions,
@@ -158,8 +156,6 @@ class ServiceObject<T = any> extends EventEmitter {
   private createMethod?: Function;
   protected methods: Methods;
   protected interceptors: Interceptor[];
-  // tslint:disable-next-line:variable-name
-  Promise?: PromiseConstructor;
 
   /*
    * @constructor
@@ -189,7 +185,6 @@ class ServiceObject<T = any> extends EventEmitter {
     this.methods = config.methods || {};
     this.interceptors = [];
     this.pollIntervalMs = config.pollIntervalMs;
-    this.Promise = this.parent ? this.parent.Promise : undefined;
 
     if (config.methods) {
       Object.getOwnPropertyNames(ServiceObject.prototype)

--- a/src/service.ts
+++ b/src/service.ts
@@ -66,7 +66,6 @@ export interface ServiceConfig {
 
 export interface ServiceOptions extends GoogleAuthOptions {
   interceptors_?: Interceptor[];
-  promise?: PromiseConstructor;
   email?: string;
   token?: string;
   timeout?: number; // http.request.options.timeout
@@ -79,8 +78,6 @@ export class Service {
   private packageJson: PackageJson;
   projectId: string;
   private projectIdRequired: boolean;
-  // tslint:disable-next-line:variable-name
-  Promise: PromiseConstructor;
   makeAuthenticatedRequest: MakeAuthenticatedRequest;
   authClient: GoogleAuth;
   private getCredentials: {};
@@ -111,7 +108,6 @@ export class Service {
     this.packageJson = config.packageJson;
     this.projectId = options.projectId || PROJECT_ID_TOKEN;
     this.projectIdRequired = config.projectIdRequired !== false;
-    this.Promise = options.promise || Promise;
 
     const reqCfg = extend({}, config, {
       projectIdRequired: this.projectIdRequired,

--- a/test/operation.ts
+++ b/test/operation.ts
@@ -37,7 +37,6 @@ describe('Operation', () => {
   let operation: Operation;
   beforeEach(() => {
     operation = new Operation({parent: FAKE_SERVICE, id: OPERATION_ID});
-    operation.Promise = Promise;
   });
 
   afterEach(() => {
@@ -91,13 +90,6 @@ describe('Operation', () => {
   describe('promise', () => {
     beforeEach(() => {
       asAny(operation).startPolling_ = () => Promise.resolve();
-    });
-
-    it('should return an instance of the localized Promise', () => {
-      class FakePromise<T> extends Promise<T> {}
-      operation.Promise = FakePromise;
-      const promise = operation.promise();
-      assert(promise instanceof FakePromise);
     });
 
     it('should reject the promise if an error occurs', () => {

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -118,16 +118,6 @@ describe('ServiceObject', () => {
       assert.strictEqual(typeof serviceObject.create, 'function');
       assert.strictEqual(serviceObject.delete, undefined);
     });
-
-    it('should localize the Promise object', () => {
-      // tslint:disable-next-line:variable-name
-      const FakePromise = () => {};
-      const config = extend({}, CONFIG, {
-        parent: {Promise: FakePromise},
-      });
-      const serviceObject = new ServiceObject(config) as FakeServiceObject;
-      assert.strictEqual(serviceObject.Promise, FakePromise);
-    });
   });
 
   describe('create', () => {

--- a/test/service.ts
+++ b/test/service.ts
@@ -208,17 +208,6 @@ describe('Service', () => {
       assert.strictEqual(service.projectIdRequired, true);
     });
 
-    it('should localize the Promise object', () => {
-      // tslint:disable-next-line:variable-name
-      const FakePromise = () => {};
-      const service = new Service(fakeCfg, {promise: FakePromise});
-      assert.strictEqual(service.Promise, FakePromise);
-    });
-
-    it('should localize the native Promise object by default', () => {
-      assert.strictEqual(service.Promise, global.Promise);
-    });
-
     it('should disable forever agent for Cloud Function envs', () => {
       process.env.FUNCTION_NAME = 'cloud-function-name';
       const service = new Service(CONFIG, OPTIONS);


### PR DESCRIPTION
BREAKING CHANGE: This removes support for custom promises.  When this feature was originally rolled out, promise support in node.js and the browser was somewhat inconsistent.  Today, all supported versions of nodejs enjoy a consistent, performant implementation of promises.   Explicitly removing this feature to ensure consistency.  