### PR TITLE
feat(service): add optional provided user agent

### DIFF
--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-console.warn(`no samples available 👎`);
+console.warn('no samples available 👎');

--- a/samples/system-test/test.js
+++ b/samples/system-test/test.js
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-console.warn(`no sample tests available 👎`);
+console.warn('no sample tests available 👎');

--- a/src/service.ts
+++ b/src/service.ts
@@ -225,7 +225,7 @@ export class Service {
     const pkg = this.packageJson;
     let userAgent = util.getUserAgentFromPackageJson(pkg);
     if (this.providedUserAgent) {
-      userAgent = `${this.providedUserAgent} ${userAgent}`
+      userAgent = `${this.providedUserAgent} ${userAgent}`;
     }
     reqOpts.headers = extend({}, reqOpts.headers, {
       'User-Agent': userAgent,

--- a/src/service.ts
+++ b/src/service.ts
@@ -67,6 +67,7 @@ export interface ServiceOptions extends GoogleAuthOptions {
   email?: string;
   token?: string;
   timeout?: number; // http.request.options.timeout
+  userAgent?: string;
 }
 
 export class Service {
@@ -76,6 +77,7 @@ export class Service {
   private packageJson: PackageJson;
   projectId: string;
   private projectIdRequired: boolean;
+  providedUserAgent?: string;
   makeAuthenticatedRequest: MakeAuthenticatedRequest;
   authClient: GoogleAuth;
   private getCredentials: {};
@@ -106,6 +108,7 @@ export class Service {
     this.packageJson = config.packageJson;
     this.projectId = options.projectId || PROJECT_ID_TOKEN;
     this.projectIdRequired = config.projectIdRequired !== false;
+    this.providedUserAgent = options.userAgent;
 
     const reqCfg = extend({}, config, {
       projectIdRequired: this.projectIdRequired,
@@ -220,8 +223,12 @@ export class Service {
     delete reqOpts.interceptors_;
 
     const pkg = this.packageJson;
+    let userAgent = util.getUserAgentFromPackageJson(pkg);
+    if (this.providedUserAgent) {
+      userAgent = `${this.providedUserAgent} ${userAgent}`
+    }
     reqOpts.headers = extend({}, reqOpts.headers, {
-      'User-Agent': util.getUserAgentFromPackageJson(pkg),
+      'User-Agent': userAgent,
       'x-goog-api-client': `gl-node/${process.versions.node} gccl/${pkg.version}`,
     });
 

--- a/test/service.ts
+++ b/test/service.ts
@@ -149,13 +149,6 @@ describe('Service', () => {
       assert.strictEqual(service.timeout, timeout);
     });
 
-    it('should localize the user agent', () => {
-      const userAgent = 'test';
-      const options = extend({}, OPTIONS, {userAgent});
-      const service = new Service(fakeCfg, options);
-      assert.strictEqual(service.providedUserAgent, userAgent);
-    });
-
     it('should localize the getCredentials method', () => {
       function getCredentials() {}
 
@@ -352,6 +345,48 @@ describe('Service', () => {
         assert.strictEqual(reqOpts_.timeout, timeout);
         done();
       };
+      service.request_(reqOpts, assert.ifError);
+    });
+
+    it('should add the User Agent', done => {
+      const userAgent = 'user-agent/0.0.0';
+
+      const getUserAgentFn = util.getUserAgentFromPackageJson;
+      util.getUserAgentFromPackageJson = packageJson => {
+        util.getUserAgentFromPackageJson = getUserAgentFn;
+        assert.strictEqual(packageJson, service.packageJson);
+        return userAgent;
+      };
+
+      service.makeAuthenticatedRequest = (reqOpts: DecorateRequestOptions) => {
+        assert.strictEqual(reqOpts.headers!['User-Agent'], userAgent);
+        done();
+      };
+
+      service.request_(reqOpts, assert.ifError);
+    });
+
+    it('should add the provided User Agent', done => {
+      const userAgent = 'user-agent/0.0.0';
+      const providedUserAgent = 'test';
+
+      service.providedUserAgent = providedUserAgent;
+
+      const getUserAgentFn = util.getUserAgentFromPackageJson;
+      util.getUserAgentFromPackageJson = packageJson => {
+        util.getUserAgentFromPackageJson = getUserAgentFn;
+        assert.strictEqual(packageJson, service.packageJson);
+        return userAgent;
+      };
+
+      service.makeAuthenticatedRequest = (reqOpts: DecorateRequestOptions) => {
+        assert.strictEqual(
+          reqOpts.headers!['User-Agent'],
+          `${providedUserAgent} ${userAgent}`
+        );
+        done();
+      };
+
       service.request_(reqOpts, assert.ifError);
     });
 

--- a/test/service.ts
+++ b/test/service.ts
@@ -149,6 +149,13 @@ describe('Service', () => {
       assert.strictEqual(service.timeout, timeout);
     });
 
+    it('should localize the user agent', () => {
+      const userAgent = 'test';
+      const options = extend({}, OPTIONS, {userAgent});
+      const service = new Service(fakeCfg, options);
+      assert.strictEqual(service.providedUserAgent, userAgent);
+    });
+
     it('should localize the getCredentials method', () => {
       function getCredentials() {}
 

--- a/test/service.ts
+++ b/test/service.ts
@@ -390,24 +390,6 @@ describe('Service', () => {
       service.request_(reqOpts, assert.ifError);
     });
 
-    it('should add the User Agent', done => {
-      const userAgent = 'user-agent/0.0.0';
-
-      const getUserAgentFn = util.getUserAgentFromPackageJson;
-      util.getUserAgentFromPackageJson = packageJson => {
-        util.getUserAgentFromPackageJson = getUserAgentFn;
-        assert.strictEqual(packageJson, service.packageJson);
-        return userAgent;
-      };
-
-      service.makeAuthenticatedRequest = (reqOpts: DecorateRequestOptions) => {
-        assert.strictEqual(reqOpts.headers!['User-Agent'], userAgent);
-        done();
-      };
-
-      service.request_(reqOpts, assert.ifError);
-    });
-
     it('should add the api-client header', done => {
       service.makeAuthenticatedRequest = (reqOpts: DecorateRequestOptions) => {
         const pkg = service.packageJson;


### PR DESCRIPTION
Supplies a way to amend the user agents used to make requests, to better track usage.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

🦕
