### PR TITLE
fix: allow non-JSON body

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -419,9 +419,7 @@ export class Util {
       try {
         parsedHttpRespBody.body = JSON.parse(body);
       } catch (err) {
-        parsedHttpRespBody.err = new ApiError(
-          `Cannot parse response as JSON: ${body}`
-        );
+        parsedHttpRespBody.body = body;
       }
     }
 


### PR DESCRIPTION
I removed the code that throws an `ApiError` if the response body turns out to be non-JSON, a bit weary of the unintended consequences this might have to our downstream libraries. This technically shouldn't occur if the API behaves correctly, i.e. always a JSON body if code is 200-299.