### PR TITLE
feat: add ServiceObject#getRequestInterceptors()

### DIFF
--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -34,6 +34,8 @@ import {
 export type RequestResponse = [Metadata, r.Response];
 
 export interface ServiceObjectParent {
+  interceptors: Interceptor[];
+  getRequestInterceptors(): Function[];
   requestStream(reqOpts: DecorateRequestOptions): r.Request;
   request(
     reqOpts: DecorateRequestOptions,
@@ -437,6 +439,17 @@ class ServiceObject<T = any> extends EventEmitter {
   }
 
   /**
+   * Return the user's custom request interceptors.
+   */
+  getRequestInterceptors(): Function[] {
+    // Interceptors should be returned in the order they were assigned.
+    const localInterceptors = this.interceptors
+      .filter(interceptor => typeof interceptor.request === 'function')
+      .map(interceptor => interceptor.request);
+    return this.parent.getRequestInterceptors().concat(localInterceptors);
+  }
+
+  /**
    * Set the metadata for this object.
    *
    * @param {object} metadata - The metadata to set on this object.
@@ -573,6 +586,6 @@ class ServiceObject<T = any> extends EventEmitter {
   }
 }
 
-promisifyAll(ServiceObject);
+promisifyAll(ServiceObject, {exclude: ['getRequestInterceptors']});
 
 export {ServiceObject};

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -188,12 +188,16 @@ class ServiceObject<T = any> extends EventEmitter {
     this.pollIntervalMs = config.pollIntervalMs;
 
     if (config.methods) {
+      // This filters the ServiceObject instance (e.g. a "File") to only have
+      // the configured methods. We make a couple of exceptions for core-
+      // functionality ("request()" and "getRequestInterceptors()")
       Object.getOwnPropertyNames(ServiceObject.prototype)
         .filter(methodName => {
           return (
-            // All ServiceObjects need `request`.
+            // All ServiceObjects need `request` and `getRequestInterceptors`.
             // clang-format off
             !/^request/.test(methodName) &&
+            !/^getRequestInterceptors/.test(methodName) &&
             // clang-format on
             // The ServiceObject didn't redefine the method.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -119,6 +119,23 @@ describe('ServiceObject', () => {
       assert.strictEqual(typeof serviceObject.create, 'function');
       assert.strictEqual(serviceObject.delete, undefined);
     });
+
+    it('should always expose the request method', () => {
+      const methods = {};
+      const config = extend({}, CONFIG, {methods});
+      const serviceObject = new ServiceObject(config);
+      assert.strictEqual(typeof serviceObject.request, 'function');
+    });
+
+    it('should always expose the getRequestInterceptors method', () => {
+      const methods = {};
+      const config = extend({}, CONFIG, {methods});
+      const serviceObject = new ServiceObject(config);
+      assert.strictEqual(
+        typeof serviceObject.getRequestInterceptors,
+        'function'
+      );
+    });
   });
 
   describe('create', () => {

--- a/test/service.ts
+++ b/test/service.ts
@@ -262,16 +262,21 @@ describe('Service', () => {
         return reqOpts;
       }
 
-      const globalInterceptors = [{request}];
-      const localInterceptors = [{request}];
+      service.globalInterceptors = [{request}];
+      service.interceptors = [{request}];
 
-      const originalGlobalInterceptors = [].slice.call(globalInterceptors);
-      const originalLocalInterceptors = [].slice.call(localInterceptors);
+      const originalGlobalInterceptors = [].slice.call(
+        service.globalInterceptors
+      );
+      const originalLocalInterceptors = [].slice.call(service.interceptors);
 
       service.getRequestInterceptors();
 
-      assert.deepStrictEqual(globalInterceptors, originalGlobalInterceptors);
-      assert.deepStrictEqual(localInterceptors, originalLocalInterceptors);
+      assert.deepStrictEqual(
+        service.globalInterceptors,
+        originalGlobalInterceptors
+      );
+      assert.deepStrictEqual(service.interceptors, originalLocalInterceptors);
     });
 
     it('should not call unrelated interceptors', () => {


### PR DESCRIPTION
Ah, the good old days of PR #589. Young, innocent @stephenplusplus thought just one method to expose the request interceptors would be enough. Until later that night, in the wee hours of the morning, he shot up instantly from his bed with a terrible shout: "What about the service objects?!"

He was right. Those lonely service object interceptors would not be accessible from the current code-- at least, not reasonably. The next day, he submitted a PR to add a new method to ServiceObject by the same name as the previous PR's addition.

This is that PR.