### PR TITLE
feat: support user-provided auth clients

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -63,6 +63,7 @@ export interface ServiceConfig {
 }
 
 export interface ServiceOptions extends GoogleAuthOptions {
+  authClient?: GoogleAuth;
   interceptors_?: Interceptor[];
   email?: string;
   token?: string;
@@ -113,6 +114,7 @@ export class Service {
     const reqCfg = extend({}, config, {
       projectIdRequired: this.projectIdRequired,
       projectId: this.projectId,
+      authClient: options.authClient,
       credentials: options.credentials,
       keyFile: options.keyFilename,
       email: options.email,

--- a/test/service.ts
+++ b/test/service.ts
@@ -28,7 +28,6 @@ import {
   util,
   Util,
 } from '../src/util';
-import {appendFile} from 'fs';
 
 proxyquire.noPreserveCache();
 
@@ -70,6 +69,7 @@ describe('Service', () => {
   };
 
   const OPTIONS = {
+    authClient: {getCredentials: () => {}},
     credentials: {},
     keyFile: {},
     email: 'email',
@@ -96,6 +96,7 @@ describe('Service', () => {
         config: MakeAuthenticatedRequestFactoryConfig
       ) => {
         const expectedConfig = extend({}, CONFIG, {
+          authClient: OPTIONS.authClient,
           credentials: OPTIONS.credentials,
           keyFile: OPTIONS.keyFilename,
           email: OPTIONS.email,
@@ -122,6 +123,11 @@ describe('Service', () => {
       };
       const service = new Service(CONFIG, OPTIONS);
       assert.strictEqual(service.authClient, authClient);
+    });
+
+    it('should localize the provided authClient', () => {
+      const service = new Service(CONFIG, OPTIONS);
+      assert.strictEqual(service.authClient, OPTIONS.authClient);
     });
 
     it('should allow passing a custom GoogleAuth client', () => {


### PR DESCRIPTION
RE: https://github.com/googleapis/nodejs-storage/issues/1284

This allows a user to provide their own GoogleAuth-flavored auth client. No code changes will be required by client libraries:

```js
const {GoogleAuth} = require('google-auth-library');
new Storage({ authClient: new GoogleAuth() });
```