### PR TITLE
chore: update google-auth-library to v7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,14 @@
     "duplexify": "^4.1.1",
     "ent": "^2.2.0",
     "extend": "^3.0.2",
-    "google-auth-library": "^6.1.1",
+    "google-auth-library": "^7.0.2",
     "retry-request": "^4.1.1",
     "teeny-request": "^7.0.0"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.11",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
     "@types/ent": "^2.2.1",
     "@types/extend": "^3.0.1",
     "@types/mocha": "^8.0.0",
@@ -67,8 +69,6 @@
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.1",
     "tmp": "0.2.1",
-    "typescript": "~3.8.3",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "typescript": "~3.8.3"
   }
 }


### PR DESCRIPTION
By updating to 7.0.2, this may likely fix https://github.com/googleapis/nodejs-translate/pull/622 which pulls in `google-auth-library` and `@google-cloud/common`. The 2 libraries are currently out of sync.
