### PR TITLE
fix: correctly locate projectId from auth library

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -614,8 +614,7 @@ export class Util {
         }
 
         if (!err || autoAuthFailed) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let projectId = await (authClient as any).getProjectId();
+          let projectId = await authClient.getProjectId();
 
           if (config.projectId && config.projectId !== '{{projectId}}') {
             projectId = config.projectId;

--- a/src/util.ts
+++ b/src/util.ts
@@ -598,7 +598,7 @@ export class Util {
       const callback =
         typeof optionsOrCallback === 'function' ? optionsOrCallback : undefined;
 
-      const onAuthenticated = (
+      const onAuthenticated = async (
         err: Error | null,
         authenticatedReqOpts?: DecorateRequestOptions
       ) => {
@@ -615,7 +615,7 @@ export class Util {
 
         if (!err || autoAuthFailed) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let projectId = (authClient as any)._cachedProjectId;
+          let projectId = await (authClient as any).getProjectId();
 
           if (config.projectId && config.projectId !== '{{projectId}}') {
             projectId = config.projectId;

--- a/src/util.ts
+++ b/src/util.ts
@@ -585,7 +585,7 @@ export class Util {
       optionsOrCallback?: MakeAuthenticatedRequestOptions | BodyResponseCallback
     ): void | Abortable | Duplexify {
       let stream: Duplexify;
-      let projectId = config.projectId;
+      let projectId: string;
       const reqConfig = extend({}, config);
       let activeRequest_: void | Abortable | null;
 
@@ -618,7 +618,7 @@ export class Util {
           try {
             authenticatedReqOpts = util.decorateRequest(
               authenticatedReqOpts!,
-              projectId!
+              projectId
             );
             err = null;
           } catch (e) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -665,7 +665,11 @@ export class Util {
       };
 
       Promise.all([
-        authClient.getProjectId(),
+        config.projectId && config.projectId !== '{{projectId}}'
+          ? // The user provided a project ID. We don't need to check with the
+            // auth client, it could be incorrect.
+            new Promise(resolve => resolve(config.projectId))
+          : authClient.getProjectId(),
         reqConfig.customEndpoint
           ? // Using a custom API override. Do not use `google-auth-library` for
             // authentication. (ex: connecting to a local Datastore server)

--- a/test/util.ts
+++ b/test/util.ts
@@ -697,9 +697,7 @@ describe('common/util', () => {
   describe('makeAuthenticatedRequestFactory', () => {
     const authClient = {
       getCredentials() {},
-      getProjectId: () => {
-        return 'authclient-project-id';
-      },
+      getProjectId: async () => 'authclient-project-id',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -887,8 +887,13 @@ describe('common/util', () => {
           });
         });
 
-        it('should use user-provided projectId', done => {
-          const config = {customEndpoint: true, projectId: 'project-id'};
+        it('should prefer user-provided projectId', done => {
+          sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
+
+          const config = {
+            customEndpoint: true,
+            projectId: 'user-provided-project-id',
+          };
 
           stub('decorateRequest', (reqOpts, projectId) => {
             assert.strictEqual(projectId, config.projectId);

--- a/test/util.ts
+++ b/test/util.ts
@@ -870,10 +870,11 @@ describe('common/util', () => {
         const reqOpts = {} as DecorateRequestOptions;
 
         it('should default to authClient projectId', done => {
+          const authClientProjectId = 'authclient-project-id';
           sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
-          authClient._cachedProjectId = 'authclient-project-id';
+          authClient.getProjectId = () => 'authclient-project-id';
           stub('decorateRequest', (reqOpts, projectId) => {
-            assert.strictEqual(projectId, authClient._cachedProjectId);
+            assert.strictEqual(projectId, authClientProjectId);
             setImmediate(done);
           });
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -697,7 +697,9 @@ describe('common/util', () => {
   describe('makeAuthenticatedRequestFactory', () => {
     const authClient = {
       getCredentials() {},
-      _cachedProjectId: 'project-id',
+      getProjectId: () => {
+        return 'authclient-project-id';
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
@@ -772,12 +774,12 @@ describe('common/util', () => {
       const config = {customEndpoint: true};
 
       beforeEach(() => {
+        sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
         makeAuthenticatedRequest = util.makeAuthenticatedRequestFactory(config);
       });
 
       it('should decorate the request', done => {
         const decoratedRequest = {};
-        sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
         stub('decorateRequest', reqOpts_ => {
           assert.strictEqual(reqOpts_, fakeReqOpts);
           return decoratedRequest;
@@ -872,7 +874,6 @@ describe('common/util', () => {
         it('should default to authClient projectId', done => {
           const authClientProjectId = 'authclient-project-id';
           sandbox.stub(fakeGoogleAuth, 'GoogleAuth').returns(authClient);
-          authClient.getProjectId = () => 'authclient-project-id';
           stub('decorateRequest', (reqOpts, projectId) => {
             assert.strictEqual(projectId, authClientProjectId);
             setImmediate(done);


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-bigquery/issues/936

Previously, the user's project ID was checked against a private property from `google-auth-library`: `_cachedProjectId`. This is not always set, including when a `keyFilename` argument is passed. I found a method from the auth library, `getProjectId()`, which will first search for, then return the most correct project ID.