### PR TITLE
feat: began retry configuration implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ent": "^2.2.0",
     "extend": "^3.0.2",
     "google-auth-library": "^7.0.2",
-    "retry-request": "^4.1.1",
+    "retry-request": "^4.2.1",
     "teeny-request": "^7.0.0"
   },
   "devDependencies": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -743,8 +743,7 @@ export class Util {
       config.autoRetry !== undefined &&
       config.retryOptions?.autoRetry !== undefined
     ) {
-      throw new ApiError('autoRetry is deprecated. Use retryOptions.autoRetry instead.')
-      );
+      throw new ApiError('autoRetry is deprecated. Use retryOptions.autoRetry instead.');
     } else if (config.autoRetry !== undefined) {
       autoRetryValue = config.autoRetry;
     } else if (config.retryOptions?.autoRetry !== undefined) {
@@ -754,8 +753,7 @@ export class Util {
     const MAX_RETRY_DEFAULT = 3;
     let maxRetryValue = MAX_RETRY_DEFAULT;
     if (config.maxRetries && config.retryOptions?.maxRetries) {
-      throw new ApiError('maxRetries is deprecated. Use retryOptions.maxRetries instead.')
-      );
+      throw new ApiError('maxRetries is deprecated. Use retryOptions.maxRetries instead.');
     } else if (config.maxRetries) {
       maxRetryValue = config.maxRetries;
     } else if (config.retryOptions?.maxRetries) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -785,6 +785,9 @@ export class Util {
         const err = util.parseHttpRespMessage(httpRespMessage).err;
         return err && util.shouldRetryRequest(err);
       },
+      maxRetryDelay: config.retryOptions?.maxRetryDelay,
+      retryDelayMultiplier: config.retryOptions?.retryDelayMultiplier,
+      totalTimeout: config.retryOptions?.totalTimeout
     } as {} as retryRequest.Options;
 
     if (typeof reqOpts.maxRetries === 'number') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -787,7 +787,7 @@ export class Util {
       },
       maxRetryDelay: config.retryOptions?.maxRetryDelay,
       retryDelayMultiplier: config.retryOptions?.retryDelayMultiplier,
-      totalTimeout: config.retryOptions?.totalTimeout
+      totalTimeout: config.retryOptions?.totalTimeout,
     } as {} as retryRequest.Options;
 
     if (typeof reqOpts.maxRetries === 'number') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,6 +40,22 @@ const requestDefaults = {
   },
 };
 
+/**
+ * Default behavior: Automatically retry retriable server errors.
+ *
+ * @const {boolean}
+ * @private
+ */
+const AUTO_RETRY_DEFAULT = true;
+
+/**
+ * Default behavior: Only attempt to retry retriable errors 3 times.
+ *
+ * @const {number}
+ * @private
+ */
+const MAX_RETRY_DEFAULT = 3;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ResponseBody = any;
 
@@ -737,7 +753,6 @@ export class Util {
     config: MakeRequestConfig,
     callback: BodyResponseCallback
   ): void | Abortable {
-    const AUTO_RETRY_DEFAULT = true;
     let autoRetryValue = AUTO_RETRY_DEFAULT;
     if (
       config.autoRetry !== undefined &&
@@ -752,7 +767,6 @@ export class Util {
       autoRetryValue = config.retryOptions.autoRetry;
     }
 
-    const MAX_RETRY_DEFAULT = 3;
     let maxRetryValue = MAX_RETRY_DEFAULT;
     if (config.maxRetries && config.retryOptions?.maxRetries) {
       throw new ApiError(

--- a/src/util.ts
+++ b/src/util.ts
@@ -764,7 +764,6 @@ export class Util {
       maxRetryValue = config.retryOptions.maxRetries;
     }
 
-    console.log('maxretryvalue', maxRetryValue);
     const options = {
       request: teenyRequest.defaults(requestDefaults),
       retries: autoRetryValue !== false ? maxRetryValue : 0,

--- a/src/util.ts
+++ b/src/util.ts
@@ -743,7 +743,9 @@ export class Util {
       config.autoRetry !== undefined &&
       config.retryOptions?.autoRetry !== undefined
     ) {
-      throw new ApiError('autoRetry is deprecated. Use retryOptions.autoRetry instead.');
+      throw new ApiError(
+        'autoRetry is deprecated. Use retryOptions.autoRetry instead.'
+      );
     } else if (config.autoRetry !== undefined) {
       autoRetryValue = config.autoRetry;
     } else if (config.retryOptions?.autoRetry !== undefined) {
@@ -753,14 +755,16 @@ export class Util {
     const MAX_RETRY_DEFAULT = 3;
     let maxRetryValue = MAX_RETRY_DEFAULT;
     if (config.maxRetries && config.retryOptions?.maxRetries) {
-      throw new ApiError('maxRetries is deprecated. Use retryOptions.maxRetries instead.');
+      throw new ApiError(
+        'maxRetries is deprecated. Use retryOptions.maxRetries instead.'
+      );
     } else if (config.maxRetries) {
       maxRetryValue = config.maxRetries;
     } else if (config.retryOptions?.maxRetries) {
       maxRetryValue = config.retryOptions.maxRetries;
     }
 
-    console.log('maxretryvalue', maxRetryValue)
+    console.log('maxretryvalue', maxRetryValue);
     const options = {
       request: teenyRequest.defaults(requestDefaults),
       retries: autoRetryValue !== false ? maxRetryValue : 0,

--- a/src/util.ts
+++ b/src/util.ts
@@ -738,30 +738,31 @@ export class Util {
     callback: BodyResponseCallback
   ): void | Abortable {
     const AUTO_RETRY_DEFAULT = true;
-    var autoRetryValue = AUTO_RETRY_DEFAULT;
-    if (config.autoRetry !== undefined && config.retryOptions?.autoRetry !== undefined) {
-      throw new ApiError("autoRetry is deprecated. Use retryOptions.autoRetry instead.")
-    }
-    else if (config.autoRetry !== undefined) {
+    let autoRetryValue = AUTO_RETRY_DEFAULT;
+    if (
+      config.autoRetry !== undefined &&
+      config.retryOptions?.autoRetry !== undefined
+    ) {
+      throw new ApiError('autoRetry is deprecated. Use retryOptions.autoRetry instead.')
+      );
+    } else if (config.autoRetry !== undefined) {
       autoRetryValue = config.autoRetry;
-    }
-    else if (config.retryOptions?.autoRetry !== undefined) {
+    } else if (config.retryOptions?.autoRetry !== undefined) {
       autoRetryValue = config.retryOptions.autoRetry;
     }
 
     const MAX_RETRY_DEFAULT = 3;
-    var maxRetryValue = MAX_RETRY_DEFAULT;
+    let maxRetryValue = MAX_RETRY_DEFAULT;
     if (config.maxRetries && config.retryOptions?.maxRetries) {
-      throw new ApiError("maxRetries is deprecated. Use retryOptions.maxRetries instead.")
-    }
-    else if (config.maxRetries) {
+      throw new ApiError('maxRetries is deprecated. Use retryOptions.maxRetries instead.')
+      );
+    } else if (config.maxRetries) {
       maxRetryValue = config.maxRetries;
-    }
-    else if (config.retryOptions?.maxRetries) {
+    } else if (config.retryOptions?.maxRetries) {
       maxRetryValue = config.retryOptions.maxRetries;
     }
 
-    console.log("maxretryvalue", maxRetryValue)
+    console.log('maxretryvalue', maxRetryValue)
     const options = {
       request: teenyRequest.defaults(requestDefaults),
       retries: autoRetryValue !== false ? maxRetryValue : 0,

--- a/test/util.ts
+++ b/test/util.ts
@@ -1224,42 +1224,54 @@ describe('common/util', () => {
     }
 
     const retryOptionsTwoMaxRetries = {
-      retryOptions: 
-      {
-        maxRetries: 7
+      retryOptions: {
+        maxRetries: 7,
       },
-      maxRetries: 7
+      maxRetries: 7,
     };
 
     const retryOptionsTwoAutoRetry = {
-      retryOptions: 
-      {
-        autoRetry: false
+      retryOptions: {
+        autoRetry: false,
       },
-      autoRetry: false
+      autoRetry: false,
     };
 
     const retryOptionsConfig = {
-      retryOptions: 
-      {
+      retryOptions: {
         autoRetry: false,
         maxRetries: 7,
         retryDelayMultiplier: 3,
         totalTimeout: 60,
-        maxRetryDelay: 640
-      }
+        maxRetryDelay: 640,
+      },
     };
     function testRetryOptions(done: () => void) {
       return (reqOpts: DecorateRequestOptions, config: MakeRequestConfig) => {
-        assert.strictEqual(config.retryOptions?.autoRetry, retryOptionsConfig.retryOptions.autoRetry);
-        assert.strictEqual(config.retryOptions?.maxRetries, retryOptionsConfig.retryOptions.maxRetries);
-        assert.strictEqual(config.retryOptions?.retryDelayMultiplier, retryOptionsConfig.retryOptions.retryDelayMultiplier);
-        assert.strictEqual(config.retryOptions?.totalTimeout, retryOptionsConfig.retryOptions.totalTimeout);
-        assert.strictEqual(config.retryOptions?.maxRetryDelay, retryOptionsConfig.retryOptions.maxRetryDelay);
+        assert.strictEqual(
+          config.retryOptions?.autoRetry,
+          retryOptionsConfig.retryOptions.autoRetry
+        );
+        assert.strictEqual(
+          config.retryOptions?.maxRetries,
+          retryOptionsConfig.retryOptions.maxRetries
+        );
+        assert.strictEqual(
+          config.retryOptions?.retryDelayMultiplier,
+          retryOptionsConfig.retryOptions.retryDelayMultiplier
+        );
+        assert.strictEqual(
+          config.retryOptions?.totalTimeout,
+          retryOptionsConfig.retryOptions.totalTimeout
+        );
+        assert.strictEqual(
+          config.retryOptions?.maxRetryDelay,
+          retryOptionsConfig.retryOptions.maxRetryDelay
+        );
         done();
       };
     }
-    
+
     const customRetryRequestConfig = {maxRetries: 10};
     function testCustomRetryRequestConfig(done: () => void) {
       return (reqOpts: DecorateRequestOptions, config: MakeRequestConfig) => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1223,6 +1223,43 @@ describe('common/util', () => {
       };
     }
 
+    const retryOptionsTwoMaxRetries = {
+      retryOptions: 
+      {
+        maxRetries: 7
+      },
+      maxRetries: 7
+    };
+
+    const retryOptionsTwoAutoRetry = {
+      retryOptions: 
+      {
+        autoRetry: false
+      },
+      autoRetry: false
+    };
+
+    const retryOptionsConfig = {
+      retryOptions: 
+      {
+        autoRetry: false,
+        maxRetries: 7,
+        retryDelayMultiplier: 3,
+        totalTimeout: 60,
+        maxRetryDelay: 640
+      }
+    };
+    function testRetryOptions(done: () => void) {
+      return (reqOpts: DecorateRequestOptions, config: MakeRequestConfig) => {
+        assert.strictEqual(config.retryOptions?.autoRetry, retryOptionsConfig.retryOptions.autoRetry);
+        assert.strictEqual(config.retryOptions?.maxRetries, retryOptionsConfig.retryOptions.maxRetries);
+        assert.strictEqual(config.retryOptions?.retryDelayMultiplier, retryOptionsConfig.retryOptions.retryDelayMultiplier);
+        assert.strictEqual(config.retryOptions?.totalTimeout, retryOptionsConfig.retryOptions.totalTimeout);
+        assert.strictEqual(config.retryOptions?.maxRetryDelay, retryOptionsConfig.retryOptions.maxRetryDelay);
+        done();
+      };
+    }
+    
     const customRetryRequestConfig = {maxRetries: 10};
     function testCustomRetryRequestConfig(done: () => void) {
       return (reqOpts: DecorateRequestOptions, config: MakeRequestConfig) => {
@@ -1374,6 +1411,25 @@ describe('common/util', () => {
       it('should override number of retries to retryRequest', done => {
         retryRequestOverride = testCustomRetryRequestConfig(done);
         util.makeRequest(reqOpts, customRetryRequestConfig, assert.ifError);
+      });
+
+      it('should use retryOptions if provided', done => {
+        retryRequestOverride = testRetryOptions(done);
+        util.makeRequest(reqOpts, retryOptionsConfig, assert.ifError);
+      });
+
+      it('should throw if autoRetry is specified twice', done => {
+        assert.throws(() => {
+          util.makeRequest(reqOpts, retryOptionsTwoAutoRetry, util.noop);
+        }, /autoRetry is deprecated. Use retryOptions.autoRetry instead\./);
+        done();
+      });
+
+      it('should throw if maxRetries is specified twice', done => {
+        assert.throws(() => {
+          util.makeRequest(reqOpts, retryOptionsTwoMaxRetries, util.noop);
+        }, /maxRetries is deprecated. Use retryOptions.maxRetries instead\./);
+        done();
       });
 
       it('should allow request options to control retry setting', done => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1217,7 +1217,7 @@ describe('common/util', () => {
 
     const noRetryRequestConfig = {autoRetry: false};
     function testNoRetryRequestConfig(done: () => void) {
-      return (reqOpts: DecorateRequestOptions, config: MakeRequestConfig) => {
+      return (reqOpts: DecorateRequestOptions, config: retryRequest.Options) => {
         assert.strictEqual(config.retries, 0);
         done();
       };
@@ -1247,25 +1247,21 @@ describe('common/util', () => {
       },
     };
     function testRetryOptions(done: () => void) {
-      return (reqOpts: DecorateRequestOptions, config: MakeRequestConfig) => {
+      return (reqOpts: DecorateRequestOptions, config: retryRequest.Options) => {
         assert.strictEqual(
-          config.retryOptions?.autoRetry,
-          retryOptionsConfig.retryOptions.autoRetry
+          config.retries,
+          0 //autoRetry was set to false, so shouldn't retry
         );
         assert.strictEqual(
-          config.retryOptions?.maxRetries,
-          retryOptionsConfig.retryOptions.maxRetries
-        );
-        assert.strictEqual(
-          config.retryOptions?.retryDelayMultiplier,
+          config.retryDelayMultiplier,
           retryOptionsConfig.retryOptions.retryDelayMultiplier
         );
         assert.strictEqual(
-          config.retryOptions?.totalTimeout,
+          config.totalTimeout,
           retryOptionsConfig.retryOptions.totalTimeout
         );
         assert.strictEqual(
-          config.retryOptions?.maxRetryDelay,
+          config.maxRetryDelay,
           retryOptionsConfig.retryOptions.maxRetryDelay
         );
         done();

--- a/test/util.ts
+++ b/test/util.ts
@@ -1217,7 +1217,10 @@ describe('common/util', () => {
 
     const noRetryRequestConfig = {autoRetry: false};
     function testNoRetryRequestConfig(done: () => void) {
-      return (reqOpts: DecorateRequestOptions, config: retryRequest.Options) => {
+      return (
+        reqOpts: DecorateRequestOptions,
+        config: retryRequest.Options
+      ) => {
         assert.strictEqual(config.retries, 0);
         done();
       };
@@ -1247,7 +1250,10 @@ describe('common/util', () => {
       },
     };
     function testRetryOptions(done: () => void) {
-      return (reqOpts: DecorateRequestOptions, config: retryRequest.Options) => {
+      return (
+        reqOpts: DecorateRequestOptions,
+        config: retryRequest.Options
+      ) => {
         assert.strictEqual(
           config.retries,
           0 //autoRetry was set to false, so shouldn't retry


### PR DESCRIPTION
Custom retry strategy behavior. Will merge all retry PRs into the shaffeeullah/storageRetryStrategy branch and then merge that branch into master at the end. This avoids one giant PR.

There is one test currently failing. I believe it is because the options that the `makeRequest` function is pulling from `retry-request` are not the options that we're looking for. This change is pending the `retry-request` library update.