### PR TITLE
fix: updated instance id to match returned metadata id

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "duplexify": "^4.1.1",
     "ent": "^2.2.0",
     "extend": "^3.0.2",
-    "google-auth-library": "^7.0.2",
+    "google-auth-library": "^7.9.2",
     "retry-request": "^4.2.2",
     "teeny-request": "^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "duplexify": "^4.1.1",
     "ent": "^2.2.0",
     "extend": "^3.0.2",
-    "google-auth-library": "^7.9.2",
+    "google-auth-library": "^7.0.2",
     "retry-request": "^4.2.2",
     "teeny-request": "^7.0.0"
   },

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -250,6 +250,9 @@ class ServiceObject<T = any> extends EventEmitter {
       const [err, instance] = args;
       if (!err) {
         self.metadata = instance.metadata;
+        if (self.id && instance.metadata){
+          self.id = instance.metadata.id;
+        }
         args[1] = self; // replace the created `instance` with this one.
       }
       callback!(...(args as {} as [Error, T]));

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -250,7 +250,7 @@ class ServiceObject<T = any> extends EventEmitter {
       const [err, instance] = args;
       if (!err) {
         self.metadata = instance.metadata;
-        if (self.id && instance.metadata){
+        if (self.id && instance.metadata) {
           self.id = instance.metadata.id;
         }
         args[1] = self; // replace the created `instance` with this one.

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -175,6 +175,28 @@ describe('ServiceObject', () => {
       serviceObject.create(options, done);
     });
 
+    it('should update id with metadata', done => {
+      const config = extend({}, CONFIG, {
+        createMethod,
+      });
+      const options = {};
+
+      function createMethod(
+        id: string,
+        options_: {},
+        callback: (err: Error | null, a: {}, b: {}) => void
+      ) {
+        assert.strictEqual(id, config.id);
+        assert.strictEqual(options_, options);
+        callback(null, {metadata: {id: 14} }, {}); // calls done()
+      }
+
+      const serviceObject = new ServiceObject(config);
+      serviceObject.create(options);
+      assert.strictEqual(serviceObject.id, 14)
+      done();
+    });
+
     it('should not require options', done => {
       const config = extend({}, CONFIG, {
         createMethod,

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -188,12 +188,12 @@ describe('ServiceObject', () => {
       ) {
         assert.strictEqual(id, config.id);
         assert.strictEqual(options_, options);
-        callback(null, {metadata: {id: 14} }, {});
+        callback(null, {metadata: {id: 14}}, {});
       }
 
       const serviceObject = new ServiceObject(config);
       serviceObject.create(options);
-      assert.strictEqual(serviceObject.id, 14)
+      assert.strictEqual(serviceObject.id, 14);
       done();
     });
 

--- a/test/service-object.ts
+++ b/test/service-object.ts
@@ -175,7 +175,7 @@ describe('ServiceObject', () => {
       serviceObject.create(options, done);
     });
 
-    it('should update id with metadata', done => {
+    it('should update id with metadata id', done => {
       const config = extend({}, CONFIG, {
         createMethod,
       });
@@ -188,7 +188,7 @@ describe('ServiceObject', () => {
       ) {
         assert.strictEqual(id, config.id);
         assert.strictEqual(options_, options);
-        callback(null, {metadata: {id: 14} }, {}); // calls done()
+        callback(null, {metadata: {id: 14} }, {});
       }
 
       const serviceObject = new ServiceObject(config);


### PR DESCRIPTION
Fixes bug where deleting, getting, and getting metadata for notifications in nodejs-storage would always 404 (because it was looking for the wrong id)
