### PR TITLE
feat: Add retry support for 504 (Gateway Timeout)

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -544,7 +544,7 @@ export class Util {
    */
   shouldRetryRequest(err?: ApiError) {
     if (err) {
-      if ([408, 429, 500, 502, 503].indexOf(err.code!) !== -1) {
+      if ([408, 429, 500, 502, 503, 504].indexOf(err.code!) !== -1) {
         return true;
       }
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -1204,6 +1204,12 @@ describe('common/util', () => {
       assert.strictEqual(util.shouldRetryRequest(error), true);
     });
 
+    it('should return true with error code 504', () => {
+      const error = new ApiError('504');
+      error.code = 504;
+      assert.strictEqual(util.shouldRetryRequest(error), true);
+    });
+
     it('should detect rateLimitExceeded reason', () => {
       const rateLimitError = new ApiError('Rate limit error without code.');
       rateLimitError.errors = [{reason: 'rateLimitExceeded'}];


### PR DESCRIPTION
Fixes a downstream issue https://github.com/googleapis/nodejs-storage/issues/1635 by adding support for gateway timeouts - which is also compliant with https://cloud.google.com/storage/docs/retry-strategy#idempotency-operations

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-common/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes https://github.com/googleapis/nodejs-storage/issues/1635 🦕
