### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,9 +1,11 @@
 {
   "name": "common",
   "name_pretty": "Google Cloud Common",
-  "release_level": "ga",
+  "release_level": "stable",
   "language": "nodejs",
   "repo": "googleapis/nodejs-common",
   "distribution_name": "@google-cloud/common",
-  "client_documentation": "https://googleapis.dev/nodejs/common/latest"
+  "client_documentation": "https://googleapis.dev/nodejs/common/latest",
+  "api_shortname": "common",
+  "library_type": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -7,5 +7,5 @@
   "distribution_name": "@google-cloud/common",
   "client_documentation": "https://googleapis.dev/nodejs/common/latest",
   "api_shortname": "common",
-  "library_type": ""
+  "library_type": "CORE"
 }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be **stable**. The code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **stable** libraries
+are addressed with the highest priority.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Google Cloud Common: Node.js Client](https://github.com/googleapis/nodejs-common)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/common.svg)](https://www.npmjs.org/package/@google-cloud/common)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-common/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-common)
 
@@ -79,12 +79,6 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 