### PR TITLE
feat: add optional projectId override in service object

### DIFF
--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -99,8 +99,8 @@ export interface ServiceObjectConfig {
 
   /**
    * Override of projectId, used to allow access to resources in another project.
-   * For example, a BigQuery dataset in another project that the user has been
-   * granted authorizatio to access.
+   * For example, a BigQuery dataset in another project to which the user has been
+   * granted permission.
    */
   projectId?: string;
 }

--- a/src/service-object.ts
+++ b/src/service-object.ts
@@ -96,6 +96,13 @@ export interface ServiceObjectConfig {
    * for completion.
    */
   pollIntervalMs?: number;
+
+  /**
+   * Override of projectId, used to allow access to resources in another project.
+   * For example, a BigQuery dataset in another project that the user has been
+   * granted authorizatio to access.
+   */
+  projectId?: string;
 }
 
 export interface Methods {
@@ -157,6 +164,7 @@ class ServiceObject<T = any> extends EventEmitter {
   private createMethod?: Function;
   protected methods: Methods;
   interceptors: Interceptor[];
+  projectId?: string;
 
   /*
    * @constructor
@@ -186,6 +194,7 @@ class ServiceObject<T = any> extends EventEmitter {
     this.methods = config.methods || {};
     this.interceptors = [];
     this.pollIntervalMs = config.pollIntervalMs;
+    this.projectId = config.projectId;
 
     if (config.methods) {
       // This filters the ServiceObject instance (e.g. a "File") to only have
@@ -545,6 +554,10 @@ class ServiceObject<T = any> extends EventEmitter {
     callback?: BodyResponseCallback
   ): void | r.Request {
     reqOpts = extend(true, {}, reqOpts);
+
+    if (this.projectId) {
+      reqOpts.projectId = this.projectId;
+    }
 
     const isAbsoluteUrl = reqOpts.uri.indexOf('http') === 0;
     const uriComponents = [this.baseUrl, this.id || '', reqOpts.uri];

--- a/src/service.ts
+++ b/src/service.ts
@@ -198,8 +198,13 @@ export class Service {
     const uriComponents = [this.baseUrl];
 
     if (this.projectIdRequired) {
-      uriComponents.push('projects');
-      uriComponents.push(this.projectId);
+      if (reqOpts.projectId) {
+        uriComponents.push('projects');
+        uriComponents.push(reqOpts.projectId);
+      } else {
+        uriComponents.push('projects');
+        uriComponents.push(this.projectId);
+      }
     }
 
     uriComponents.push(reqOpts.uri);

--- a/src/util.ts
+++ b/src/util.ts
@@ -219,6 +219,7 @@ export interface DecorateRequestOptions extends r.CoreOptions {
   uri: string;
   interceptors_?: Interceptor[];
   shouldReturnStream?: boolean;
+  projectId?: string;
 }
 
 export interface ParsedHttpResponseBody {

--- a/test/service.ts
+++ b/test/service.ts
@@ -534,7 +534,7 @@ describe('Service', () => {
           service.request_(reqOpts, assert.ifError);
         });
 
-        it('should not include the projectId if override', done => {
+        it('should use projectId override', done => {
           const config = extend({}, CONFIG, {projectIdRequired: true});
           const service = new Service(config, OPTIONS);
           const projectOverride = 'turing';

--- a/test/service.ts
+++ b/test/service.ts
@@ -533,6 +533,31 @@ describe('Service', () => {
 
           service.request_(reqOpts, assert.ifError);
         });
+
+        it('should not include the projectId if override', done => {
+          const config = extend({}, CONFIG, {projectIdRequired: true});
+          const service = new Service(config, OPTIONS);
+          const projectOverride = 'turing';
+
+          reqOpts.projectId = projectOverride;
+
+          const expectedUri = [
+            service.baseUrl,
+            'projects',
+            projectOverride,
+            reqOpts.uri,
+          ].join('/');
+
+          service.makeAuthenticatedRequest = (
+            reqOpts_: DecorateRequestOptions
+          ) => {
+            assert.strictEqual(reqOpts_.uri, expectedUri);
+
+            done();
+          };
+
+          service.request_(reqOpts, assert.ifError);
+        });
       });
     });
 


### PR DESCRIPTION
This will allow libraries like [nodejs-bigquery](https://github.com/googleapis/nodejs-bigquery) to implement cross-project support.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

🦕
