### PR TITLE
fix: replace `ent` with `html-entities`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,15 +36,14 @@
     "@google-cloud/promisify": "^4.0.0",
     "arrify": "^2.0.1",
     "duplexify": "^4.1.1",
-    "ent": "^2.2.0",
     "extend": "^3.0.2",
     "google-auth-library": "^9.0.0",
+    "html-entities": "^2.5.2",
     "retry-request": "^7.0.0",
     "teeny-request": "^9.0.0"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.11",
-    "@types/ent": "^2.2.1",
     "@types/extend": "^3.0.1",
     "@types/mocha": "^9.0.0",
     "@types/mv": "^2.1.0",

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,7 +20,7 @@ import {
   replaceProjectIdToken,
   MissingProjectIdError,
 } from '@google-cloud/projectify';
-import * as ent from 'ent';
+import * as htmlEntities from 'html-entities';
 import * as extend from 'extend';
 import {AuthClient, GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import {CredentialBody} from 'google-auth-library';
@@ -291,7 +291,7 @@ export class ApiError extends Error {
     if (errors && errors.length) {
       errors.forEach(({message}) => messages.add(message!));
     } else if (err.response && err.response.body) {
-      messages.add(ent.decode(err.response.body.toString()));
+      messages.add(htmlEntities.decode(err.response.body.toString()));
     } else if (!err.message) {
       messages.add('A failure occurred during this request.');
     }


### PR DESCRIPTION
Fixes #812 

This PR replaces `ent` with `html-entities`.

BEGIN_COMMIT_OVERRIDE
fix: replace ent with html-entities
Release-As: 5.0.2
END_COMMIT_OVERRIDE