### PR TITLE
chore(deps): pin `@compodoc/compodoc` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "teeny-request": "^9.0.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.11",
+    "@compodoc/compodoc": "1.1.23",
     "@types/ent": "^2.2.1",
     "@types/extend": "^3.0.1",
     "@types/mocha": "^9.0.0",


### PR DESCRIPTION
This PR fixes the [following CI error](https://github.com/googleapis/nodejs-common/actions/runs/8696396942/job/24212891011?pr=813):

```bash
$ npm install --production --engine-strict --ignore-scripts --no-package-lock

npm WARN config production Use `--omit=dev` instead.
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: @angular-devkit/schematics@17.3.5
npm ERR! notsup Not compatible with your version of node/npm: @angular-devkit/schematics@17.3.5
npm ERR! notsup Required: {"node":"^18.13.0 || >=20.9.0","npm":"^6.11.0 || ^7.5.6 || >=8.0.0","yarn":">= 1.13.0"}
npm ERR! notsup Actual:   {"npm":"8.19.[4](https://github.com/googleapis/nodejs-common/actions/runs/8696396942/job/24212891011?pr=813#step:5:5)","node":"v16.20.2"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2024-04-24T1[6](https://github.com/googleapis/nodejs-common/actions/runs/8696396942/job/24212891011?pr=813#step:5:7)_36_23_094Z-debug-0.log
```

The latest version of `@compodoc/compodoc` (`1.1.24`) [bumped the version](https://github.com/compodoc/compodoc/compare/1.1.23...1.1.24#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R88) of their `@angular-devkit/schematics` dependency, which doesn't support Node 16 anymore.

The solution is to pin `@compodoc/compodoc` to the last non-breaking patch version.